### PR TITLE
Feat/unsaved changes toolbar

### DIFF
--- a/_extensions/editable/editable.js
+++ b/_extensions/editable/editable.js
@@ -14,13 +14,11 @@ window.Revealeditable = function () {
 };
 
 function addSaveMenuButton() {
-  // Find the slide-menu-items ul inside menu-custom-panel div
   const slideMenuItems = document.querySelector(
     "div.slide-menu-custom-panel ul.slide-menu-items"
   );
 
   if (slideMenuItems) {
-    // Find the highest data-item value
     const existingItems = slideMenuItems.querySelectorAll("li[data-item]");
     let maxDataItem = 0;
     existingItems.forEach((item) => {
@@ -30,14 +28,12 @@ function addSaveMenuButton() {
       }
     });
 
-    // Create the new li element
     const newLi = document.createElement("li");
     newLi.className = "slide-tool-item";
     newLi.setAttribute("data-item", (maxDataItem + 1).toString());
     newLi.innerHTML =
       '<a href="#" onclick="saveMovedElts()"><kbd>?</kbd> Save Edits</a>';
 
-    // Append to the ul
     slideMenuItems.appendChild(newLi);
   }
 }
@@ -107,7 +103,6 @@ function setupDraggableElt(elt) {
       container.appendChild(handle);
     });
 
-    // Create font size controls for div elements
     if (elt.tagName.toLowerCase() === "div") {
       const fontControls = document.createElement("div");
       fontControls.className = "font-controls";
@@ -125,7 +120,6 @@ function setupDraggableElt(elt) {
       const increaseBtn = createButton("A+", "24px", "4px 12px");
       increaseBtn.style.marginRight = "10px";
 
-      // Create text alignment controls
       const alignLeftBtn = createButton("⇤", "20px", "4px 12px");
       alignLeftBtn.title = "Align Left";
 
@@ -147,7 +141,6 @@ function setupDraggableElt(elt) {
       fontControls.appendChild(editBtn);
       container.appendChild(fontControls);
 
-      // Add event listeners for font size controls
       decreaseBtn.addEventListener("click", (e) => {
         e.stopPropagation();
         changeFontSize(elt, -2);
@@ -158,7 +151,6 @@ function setupDraggableElt(elt) {
         changeFontSize(elt, 2);
       });
 
-      // Add event listeners for text alignment controls
       alignLeftBtn.addEventListener("click", (e) => {
         e.stopPropagation();
         elt.style.textAlign = "left";
@@ -174,7 +166,6 @@ function setupDraggableElt(elt) {
         elt.style.textAlign = "right";
       });
 
-      // Add event listener for edit button
       editBtn.addEventListener("click", (e) => {
         e.stopPropagation();
         const isEditable = elt.contentEditable === "true";
@@ -227,10 +218,6 @@ function setupDraggableElt(elt) {
 
   function getClientCoordinates(e) {
     const isTouch = e.type.startsWith("touch");
-
-    // revealjs scales this .slides container element so that
-    // the slide fits completely in the viewport. We have to
-    // adjust the mouse/touch positions by this scaling.
     const slidesContainerEl = document.querySelector(".slides");
     const scale = window
       .getComputedStyle(slidesContainerEl)
@@ -315,12 +302,10 @@ function setupDraggableElt(elt) {
     let newX = initialX;
     let newY = initialY;
 
-    // Check if Shift key is pressed for aspect ratio preservation
     const preserveAspectRatio = e.shiftKey;
     const aspectRatio = initialWidth / initialHeight;
 
     if (preserveAspectRatio) {
-      // For corner handles, use the larger delta to maintain aspect ratio
       if (resizeHandle.includes("e") || resizeHandle.includes("w")) {
         const widthChange = resizeHandle.includes("e") ? deltaX : -deltaX;
         newWidth = Math.max(50, initialWidth + widthChange);
@@ -331,7 +316,6 @@ function setupDraggableElt(elt) {
         newWidth = newHeight * aspectRatio;
       }
 
-      // Adjust position for west/north handles when preserving aspect ratio
       if (resizeHandle.includes("w")) {
         newX = initialX + (initialWidth - newWidth);
       }
@@ -339,7 +323,6 @@ function setupDraggableElt(elt) {
         newY = initialY + (initialHeight - newHeight);
       }
     } else {
-      // Original free resize behavior
       if (resizeHandle.includes("e")) {
         newWidth = Math.max(50, initialWidth + deltaX);
       }
@@ -386,7 +369,7 @@ function setupDraggableElt(elt) {
   function changeFontSize(element, delta) {
     const currentFontSize =
       parseFloat(window.getComputedStyle(element).fontSize) || 16;
-    const newFontSize = Math.max(8, currentFontSize + delta); // Minimum font size of 8px
+    const newFontSize = Math.max(8, currentFontSize + delta);
     element.style.fontSize = newFontSize + "px";
   }
 
@@ -405,7 +388,8 @@ function setupDraggableElt(elt) {
 }
 
 function saveMovedElts() {
-  index = readIndexQmd();
+  // Decode the base64-encoded source file
+  let index = readIndexQmd();
   Elt_dim = extracteditableEltDimensions();
 
   index = udpdateTextDivs(index);
@@ -413,20 +397,12 @@ function saveMovedElts() {
   Elt_attr = formateditableEltStrings(Elt_dim);
   index = replaceeditableOccurrences(index, Elt_attr);
 
-  index = preserveBackSlashes(index);
+
+
   downloadString(index);
 }
 
-function preserveBackSlashes(index) {
-  // avoid removing some backslashes
-  index = index.replaceAll("\\", "\\\\");
-  index = index.replaceAll("\\\\(", "\\(");
-  index = index.replaceAll("\\\\)", "\\)");
-  index = index.replace(/ +(?=\n)/g, (match) => "\\ ".repeat(match.length));
-  return index;
-}
-
-// Function to read index.qmd file
+// Function to read index.qmd file (decoded from base64 by atob() at load time)
 function readIndexQmd() {
   return window._input_file;
 }
@@ -449,7 +425,6 @@ function extracteditableEltDimensions() {
       ? parseFloat(elt.style.height)
       : elt.offsetHeight;
 
-    // Get parent container (div) position
     const parentContainer = elt.parentNode;
     const left = parentContainer.style.left
       ? parseFloat(parentContainer.style.left)
@@ -465,11 +440,9 @@ function extracteditableEltDimensions() {
       top: top,
     };
 
-    // Add font-size for div elements if it's set
     if (elt.tagName.toLowerCase() === "div" && elt.style.fontSize) {
       dimensionData.fontSize = parseFloat(elt.style.fontSize);
     }
-    // Add text-align for div elements if it's set
     if (elt.tagName.toLowerCase() === "div" && elt.style.textAlign) {
       dimensionData.textAlign = elt.style.textAlign;
     }
@@ -480,7 +453,6 @@ function extracteditableEltDimensions() {
   return dimensions;
 }
 
-// Function to replace all occurrences that start with "{.editable" and go until the first "}" with replacements from array
 function udpdateTextDivs(text) {
   divs = getEditableDivs();
   replacements = Array.from(divs).map(htmlToQuarto);
@@ -514,7 +486,6 @@ function htmlToQuarto(div) {
   return text;
 }
 
-// Function to replace all occurrences that start with "{.editable" and go until the first "}" with replacements from array
 function replaceeditableOccurrences(text, replacements) {
   const regex = /\{\.editable[^}]*\}|::: ?editable/g;
 
@@ -524,7 +495,6 @@ function replaceeditableOccurrences(text, replacements) {
   });
 }
 
-// Function to format editable dimensions as strings
 function formateditableEltStrings(dimensions) {
   return dimensions.map((dim) => {
     let str = `{.absolute width=${dim.width}px height=${dim.height}px left=${dim.left}px top=${dim.top}px`;
@@ -536,7 +506,6 @@ function formateditableEltStrings(dimensions) {
       if (dim.fontSize && dim.textAlign) {
         str += ` `;
       }
-
       if (dim.textAlign) {
         str += `text-align: ${dim.textAlign};`;
       }
@@ -547,13 +516,10 @@ function formateditableEltStrings(dimensions) {
   });
 }
 
-// Function to make a string available as a downloadable file
 async function downloadString(content, mimeType = "text/plain") {
   filename = geteditableFilename();
-  // Check if the File System Access API is supported
   if ("showSaveFilePicker" in window) {
     try {
-      // Show file picker dialog
       const fileHandle = await window.showSaveFilePicker({
         suggestedName: filename,
         types: [
@@ -564,7 +530,6 @@ async function downloadString(content, mimeType = "text/plain") {
         ],
       });
 
-      // Create a writable stream and write the content
       const writable = await fileHandle.createWritable();
       await writable.write(content);
       await writable.close();
@@ -572,12 +537,10 @@ async function downloadString(content, mimeType = "text/plain") {
       console.log("File saved successfully");
       return;
     } catch (error) {
-      // User cancelled or error occurred, fall back to traditional method
       console.log("File picker cancelled or failed, using fallback method");
     }
   }
 
-  // Fallback to traditional download method
   const blob = new Blob([content], { type: mimeType });
   const url = URL.createObjectURL(blob);
 

--- a/_extensions/editable/editable.js
+++ b/_extensions/editable/editable.js
@@ -29,10 +29,20 @@ function addSaveMenuButton() {
     });
 
     const newLi = document.createElement("li");
-    newLi.className = "slide-tool-item";
+    newLi.className = "slide-menu-item";
     newLi.setAttribute("data-item", (maxDataItem + 1).toString());
-    newLi.innerHTML =
-      '<a href="#" onclick="saveMovedElts()"><kbd>?</kbd> Save Edits</a>';
+
+    const newA = document.createElement("a");
+    newA.href = "#";
+    const kbd = document.createElement("kbd");
+    kbd.textContent = "?";
+    newA.appendChild(kbd);
+    newA.appendChild(document.createTextNode(" Save Edits"));
+    newA.addEventListener("click", function (e) {
+      e.preventDefault();
+      saveMovedElts();
+    });
+    newLi.appendChild(newA);
 
     slideMenuItems.appendChild(newLi);
   }
@@ -388,7 +398,6 @@ function setupDraggableElt(elt) {
 }
 
 function saveMovedElts() {
-  // Decode the base64-encoded source file
   let index = readIndexQmd();
   Elt_dim = extracteditableEltDimensions();
 
@@ -396,8 +405,6 @@ function saveMovedElts() {
 
   Elt_attr = formateditableEltStrings(Elt_dim);
   index = replaceeditableOccurrences(index, Elt_attr);
-
-
 
   downloadString(index);
 }

--- a/_extensions/editable/editable.js
+++ b/_extensions/editable/editable.js
@@ -45,6 +45,25 @@ function addSaveMenuButton() {
     newLi.appendChild(newA);
 
     slideMenuItems.appendChild(newLi);
+
+    // Add "Copy qmd to clipboard" button
+    const copyLi = document.createElement("li");
+    copyLi.className = "slide-tool-item";
+    copyLi.setAttribute("data-item", (maxDataItem + 2).toString());
+
+    const copyA = document.createElement("a");
+    copyA.href = "#";
+    const copyKbd = document.createElement("kbd");
+    copyKbd.textContent = "c";
+    copyA.appendChild(copyKbd);
+    copyA.appendChild(document.createTextNode(" Copy qmd to Clipboard"));
+    copyA.addEventListener("click", function (e) {
+      e.preventDefault();
+      copyQmdToClipboard();
+    });
+    copyLi.appendChild(copyA);
+
+    slideMenuItems.appendChild(copyLi);
   }
 }
 
@@ -412,6 +431,23 @@ function saveMovedElts() {
 // Function to read index.qmd file (decoded from base64 by atob() at load time)
 function readIndexQmd() {
   return window._input_file;
+}
+
+// Function to copy the modified qmd content to clipboard (closes #8)
+function copyQmdToClipboard() {
+  let index = readIndexQmd();
+  Elt_dim = extracteditableEltDimensions();
+
+  index = udpdateTextDivs(index);
+
+  Elt_attr = formateditableEltStrings(Elt_dim);
+  index = replaceeditableOccurrences(index, Elt_attr);
+
+  navigator.clipboard.writeText(index).then(function () {
+    console.log("qmd content copied to clipboard");
+  }).catch(function (err) {
+    console.error("Failed to copy to clipboard:", err);
+  });
 }
 
 // Function to get data-filename attribute from editable div

--- a/_extensions/editable/editable.js
+++ b/_extensions/editable/editable.js
@@ -1,3 +1,124 @@
+// ─── Floating dirty-state toolbar ────────────────────────────────────────────
+
+(function () {
+  var toolbar = null;
+  var hideTimer = null;
+
+  function createToolbar() {
+    if (document.getElementById('editable-toolbar')) return;
+
+    var t = document.createElement('div');
+    t.id = 'editable-toolbar';
+    t.style.cssText = [
+      'position: fixed',
+      'bottom: 0',
+      'left: 0',
+      'right: 0',
+      'height: 48px',
+      'background: rgba(10, 10, 20, 0.78)',
+      'backdrop-filter: blur(12px)',
+      '-webkit-backdrop-filter: blur(12px)',
+      'border-top: 1px solid rgba(255,255,255,0.07)',
+      'display: flex',
+      'align-items: center',
+      'padding: 0 20px',
+      'gap: 10px',
+      'z-index: 9999',
+      'transform: translateY(100%)',
+      'transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1)',
+      'font-family: ui-monospace, "SF Mono", monospace',
+      'font-size: 12px',
+    ].join(';');
+
+    // dot
+    var dot = document.createElement('span');
+    dot.id = 'editable-toolbar-dot';
+    dot.style.cssText = 'width:8px;height:8px;border-radius:50%;background:#e0c36a;display:inline-block;flex-shrink:0;transition:background 0.4s ease';
+
+    // label
+    var label = document.createElement('span');
+    label.id = 'editable-toolbar-label';
+    label.style.cssText = 'color:#bdbdbd;letter-spacing:0.06em;flex:1;';
+    label.textContent = 'unsaved changes';
+
+    // dismiss button
+    var dismiss = document.createElement('button');
+    dismiss.textContent = '×';
+    dismiss.style.cssText = 'background:transparent;border:none;color:#fff;font-size:18px;cursor:pointer;padding:0 6px;line-height:1;';
+    dismiss.title = 'Dismiss';
+    dismiss.addEventListener('click', function () { hideToolbar(); });
+
+    // copy button
+    var btnCopy = document.createElement('button');
+    btnCopy.id = 'editable-toolbar-copy';
+    btnCopy.textContent = '📋 Copy to clipboard';
+    btnCopy.style.cssText = 'background:#007cba;border:none;color:white;font-size:12px;font-family:inherit;padding:0 14px;height:30px;border-radius:3px;cursor:pointer;letter-spacing:0.04em;';
+    btnCopy.addEventListener('mouseenter', function() { this.style.background='#0090d4'; });
+    btnCopy.addEventListener('mouseleave', function() { this.style.background='#007cba'; });
+    btnCopy.addEventListener('click', function (e) { e.preventDefault(); copyQmdToClipboard(); });
+
+    // save button
+    var btnSave = document.createElement('button');
+    btnSave.id = 'editable-toolbar-save';
+    btnSave.textContent = '💾 Save edits';
+    btnSave.style.cssText = 'background:#da7756;border:none;color:white;font-size:12px;font-family:inherit;padding:0 16px;height:30px;border-radius:3px;cursor:pointer;letter-spacing:0.04em;';
+    btnSave.addEventListener('mouseenter', function() { this.style.background='#e08868'; });
+    btnSave.addEventListener('mouseleave', function() { this.style.background='#da7756'; });
+    btnSave.addEventListener('click', function (e) { e.preventDefault(); saveMovedElts(); });
+
+    t.appendChild(dot);
+    t.appendChild(label);
+    t.appendChild(dismiss);
+    t.appendChild(btnCopy);
+    t.appendChild(btnSave);
+    document.body.appendChild(t);
+    toolbar = t;
+  }
+
+  function showToolbar() {
+    createToolbar();
+    if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+    // reset to dirty state
+    var dot = document.getElementById('editable-toolbar-dot');
+    var label = document.getElementById('editable-toolbar-label');
+    if (dot) dot.style.background = '#e0c36a';
+    if (label) label.textContent = 'unsaved changes';
+    // slide in
+    setTimeout(function () {
+      toolbar.style.transform = 'translateY(0)';
+    }, 10);
+  }
+
+  function hideToolbar() {
+    if (!toolbar) return;
+    toolbar.style.transform = 'translateY(100%)';
+  }
+
+  function showSavedFeedback(type) {
+    if (!toolbar) return;
+    var dot = document.getElementById('editable-toolbar-dot');
+    var label = document.getElementById('editable-toolbar-label');
+    if (dot) dot.style.background = '#4caf82';
+    if (label) {
+      if (type === 'copy') {
+        label.textContent = 'copied! → paste into your .qmd to apply changes';
+      } else {
+        label.textContent = 'downloaded! → replace your original .qmd if satisfied';
+      }
+    }
+    hideTimer = setTimeout(function () { hideToolbar(); }, 3500);
+  }
+
+  // Expose globally
+  window._editableToolbar = {
+    show: showToolbar,
+    showSaved: showSavedFeedback,
+    hide: hideToolbar,
+  };
+})();
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 window.Revealeditable = function () {
   return {
     id: "Revealeditable",
@@ -45,6 +166,25 @@ function addSaveMenuButton() {
     newLi.appendChild(newA);
 
     slideMenuItems.appendChild(newLi);
+
+    // Add "Copy qmd to clipboard" button
+    const copyLi = document.createElement("li");
+    copyLi.className = "slide-tool-item";
+    copyLi.setAttribute("data-item", (maxDataItem + 2).toString());
+
+    const copyA = document.createElement("a");
+    copyA.href = "#";
+    const copyKbd = document.createElement("kbd");
+    copyKbd.textContent = "c";
+    copyA.appendChild(copyKbd);
+    copyA.appendChild(document.createTextNode(" Copy qmd to Clipboard"));
+    copyA.addEventListener("click", function (e) {
+      e.preventDefault();
+      copyQmdToClipboard();
+    });
+    copyLi.appendChild(copyA);
+
+    slideMenuItems.appendChild(copyLi);
   }
 }
 
@@ -184,6 +324,10 @@ function setupDraggableElt(elt) {
         editBtn.title = !isEditable ? "Exit Edit Mode" : "Toggle Edit Mode";
         if (!isEditable) {
           elt.focus();
+          // Show dirty toolbar on any text input while in edit mode
+          elt.addEventListener("input", function () {
+            window._editableToolbar.show();
+          }, { once: false });
         }
       });
     }
@@ -359,6 +503,8 @@ function setupDraggableElt(elt) {
 
   function stopAction() {
     if (isDragging || isResizing) {
+      // Show dirty toolbar when a drag or resize ends
+      window._editableToolbar.show();
       setTimeout(() => {
         if (!container.matches(":hover")) {
           container.style.border = "2px solid transparent";
@@ -398,7 +544,6 @@ function setupDraggableElt(elt) {
 }
 
 function saveMovedElts() {
-  // Decode the base64-encoded source file
   let index = readIndexQmd();
   Elt_dim = extracteditableEltDimensions();
 
@@ -407,14 +552,31 @@ function saveMovedElts() {
   Elt_attr = formateditableEltStrings(Elt_dim);
   index = replaceeditableOccurrences(index, Elt_attr);
 
-
-
   downloadString(index);
+  window._editableToolbar.showSaved('save');
 }
 
 // Function to read index.qmd file (decoded from base64 by atob() at load time)
 function readIndexQmd() {
   return window._input_file;
+}
+
+// Function to copy the modified qmd content to clipboard (closes #8)
+function copyQmdToClipboard() {
+  let index = readIndexQmd();
+  Elt_dim = extracteditableEltDimensions();
+
+  index = udpdateTextDivs(index);
+
+  Elt_attr = formateditableEltStrings(Elt_dim);
+  index = replaceeditableOccurrences(index, Elt_attr);
+
+  navigator.clipboard.writeText(index).then(function () {
+    console.log("qmd content copied to clipboard");
+    window._editableToolbar.showSaved('copy');
+  }).catch(function (err) {
+    console.error("Failed to copy to clipboard:", err);
+  });
 }
 
 // Function to get data-filename attribute from editable div

--- a/_extensions/editable/editable.js
+++ b/_extensions/editable/editable.js
@@ -45,25 +45,6 @@ function addSaveMenuButton() {
     newLi.appendChild(newA);
 
     slideMenuItems.appendChild(newLi);
-
-    // Add "Copy qmd to clipboard" button
-    const copyLi = document.createElement("li");
-    copyLi.className = "slide-tool-item";
-    copyLi.setAttribute("data-item", (maxDataItem + 2).toString());
-
-    const copyA = document.createElement("a");
-    copyA.href = "#";
-    const copyKbd = document.createElement("kbd");
-    copyKbd.textContent = "c";
-    copyA.appendChild(copyKbd);
-    copyA.appendChild(document.createTextNode(" Copy qmd to Clipboard"));
-    copyA.addEventListener("click", function (e) {
-      e.preventDefault();
-      copyQmdToClipboard();
-    });
-    copyLi.appendChild(copyA);
-
-    slideMenuItems.appendChild(copyLi);
   }
 }
 
@@ -417,6 +398,7 @@ function setupDraggableElt(elt) {
 }
 
 function saveMovedElts() {
+  // Decode the base64-encoded source file
   let index = readIndexQmd();
   Elt_dim = extracteditableEltDimensions();
 
@@ -424,6 +406,8 @@ function saveMovedElts() {
 
   Elt_attr = formateditableEltStrings(Elt_dim);
   index = replaceeditableOccurrences(index, Elt_attr);
+
+
 
   downloadString(index);
 }
@@ -431,23 +415,6 @@ function saveMovedElts() {
 // Function to read index.qmd file (decoded from base64 by atob() at load time)
 function readIndexQmd() {
   return window._input_file;
-}
-
-// Function to copy the modified qmd content to clipboard (closes #8)
-function copyQmdToClipboard() {
-  let index = readIndexQmd();
-  Elt_dim = extracteditableEltDimensions();
-
-  index = udpdateTextDivs(index);
-
-  Elt_attr = formateditableEltStrings(Elt_dim);
-  index = replaceeditableOccurrences(index, Elt_attr);
-
-  navigator.clipboard.writeText(index).then(function () {
-    console.log("qmd content copied to clipboard");
-  }).catch(function (err) {
-    console.error("Failed to copy to clipboard:", err);
-  });
 }
 
 // Function to get data-filename attribute from editable div

--- a/_extensions/editable/editable.lua
+++ b/_extensions/editable/editable.lua
@@ -23,7 +23,44 @@ local function b64encode(data)
   return table.concat(result)
 end
 
+-- Check if a Pandoc element has the class "editable"
+local function has_editable_class(el)
+  if el.attr and el.attr.classes then
+    for _, cls in ipairs(el.attr.classes) do
+      if cls == 'editable' then return true end
+    end
+  end
+  return false
+end
+
+-- Walk the AST looking for Div or Image elements with class "editable".
+-- These are the only elements the JS targets: div.editable and img.editable.
+-- Using the AST avoids any risk of false positives on the word "editable"
+-- appearing in plain text or code blocks.
+local found_editable = false
+
+function Div(el)
+  if has_editable_class(el) then
+    found_editable = true
+  end
+  return el
+end
+
+function Image(el)
+  if has_editable_class(el) then
+    found_editable = true
+  end
+  return el
+end
+
 function Pandoc(doc)
+  -- No editable elements found: skip injection entirely.
+  -- This keeps the generated HTML clean after a save (when all {.editable}
+  -- have been replaced by {.absolute ...}) and avoids unnecessary base64
+  -- encoding when the filter is active but unused.
+  if not found_editable then return doc end
+
+  -- Encode qmd source as base64 and inject into <head>
   local filename = quarto.doc.input_file
   local text = assert(io.open(filename, "r")):read("a")
   local encoded = b64encode(text)

--- a/_extensions/editable/editable.lua
+++ b/_extensions/editable/editable.lua
@@ -66,7 +66,11 @@ function Pandoc(doc)
   local encoded = b64encode(text)
 
   local script = "<script>\n"
-  script = script .. "window._input_file = atob('" .. encoded .. "');\n"
+  -- Use TextDecoder to properly handle UTF-8 encoded characters (accents, etc.)
+  -- atob() alone returns a binary Latin-1 string and corrupts non-ASCII chars.
+  script = script .. "window._input_file = new TextDecoder('utf-8').decode(\n"
+  script = script .. "  Uint8Array.from(atob('" .. encoded .. "'), function(c) { return c.charCodeAt(0); })\n"
+  script = script .. ");\n"
   script = script .. "window._input_filename = '" .. filename .. "';\n"
   script = script .. "</script>"
 

--- a/_extensions/editable/editable.lua
+++ b/_extensions/editable/editable.lua
@@ -1,25 +1,36 @@
--- Pure Lua base64 encoder
+-- Standard base64 encoder (RFC 4648), pure Lua
 local function b64encode(data)
-  local b = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
-  return ((data:gsub('.', function(x)
-    local r, b64 = '', x:byte()
-    for i = 8, 1, -1 do r = r .. (b64 % 2^i - b64 % 2^(i-1) > 0 and '1' or '0') end
-    return r
-  end) .. '0000'):gsub('%d%d%d%d%d%d', function(x)
-    if #x < 6 then return '' end
-    local c = 0
-    for i = 1, 6 do c = c + (x:sub(i,i) == '1' and 2^(6-i) or 0) end
-    return b:sub(c+1, c+1)
-  end) .. ({'', '==', '='})[#data % 3 + 1])
+  local chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+  local result = {}
+  local pad = 0
+
+  for i = 1, #data, 3 do
+    local b1 = data:byte(i) or 0
+    local b2 = data:byte(i+1) or 0
+    local b3 = data:byte(i+2) or 0
+
+    if i+1 > #data then pad = 2
+    elseif i+2 > #data then pad = 1 end
+
+    local n = b1 * 65536 + b2 * 256 + b3
+
+    table.insert(result, chars:sub(math.floor(n / 262144) % 64 + 1, math.floor(n / 262144) % 64 + 1))
+    table.insert(result, chars:sub(math.floor(n / 4096)   % 64 + 1, math.floor(n / 4096)   % 64 + 1))
+    table.insert(result, pad == 2 and '=' or chars:sub(math.floor(n / 64) % 64 + 1, math.floor(n / 64) % 64 + 1))
+    table.insert(result, pad >= 1 and '=' or chars:sub(n % 64 + 1, n % 64 + 1))
+  end
+
+  return table.concat(result)
 end
 
 function Pandoc(doc)
-  local text = assert(io.open(quarto.doc.input_file, "r")):read("a")
+  local filename = quarto.doc.input_file
+  local text = assert(io.open(filename, "r")):read("a")
   local encoded = b64encode(text)
 
   local script = "<script>\n"
   script = script .. "window._input_file = atob('" .. encoded .. "');\n"
-  script = script .. "window._input_filename = '" .. quarto.doc.input_file .. "';\n"
+  script = script .. "window._input_filename = '" .. filename .. "';\n"
   script = script .. "</script>"
 
   local tmpfile = os.tmpname() .. ".html"

--- a/_extensions/editable/editable.lua
+++ b/_extensions/editable/editable.lua
@@ -1,12 +1,32 @@
+-- Pure Lua base64 encoder
+local function b64encode(data)
+  local b = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+  return ((data:gsub('.', function(x)
+    local r, b64 = '', x:byte()
+    for i = 8, 1, -1 do r = r .. (b64 % 2^i - b64 % 2^(i-1) > 0 and '1' or '0') end
+    return r
+  end) .. '0000'):gsub('%d%d%d%d%d%d', function(x)
+    if #x < 6 then return '' end
+    local c = 0
+    for i = 1, 6 do c = c + (x:sub(i,i) == '1' and 2^(6-i) or 0) end
+    return b:sub(c+1, c+1)
+  end) .. ({'', '==', '='})[#data % 3 + 1])
+end
+
 function Pandoc(doc)
   local text = assert(io.open(quarto.doc.input_file, "r")):read("a")
-  text = string.gsub(text, "\"", "\\\"")
-  text = string.gsub(text, "\n", "\\n\" + \"")
-  text = "\"" .. text .. "\""
-  text = string.gsub(text, "\\%(", "\\\\(")
-  text = string.gsub(text, "\\%)", "\\\\)")
+  local encoded = b64encode(text)
 
-  doc.blocks:insert(pandoc.RawBlock("html", "<script> window._input_file = " .. text .. "</script>"))
-  doc.blocks:insert(pandoc.RawBlock("html", "<script> window._input_filename = '" .. quarto.doc.input_file .. "'</script>"))
+  local script = "<script>\n"
+  script = script .. "window._input_file = atob('" .. encoded .. "');\n"
+  script = script .. "window._input_filename = '" .. quarto.doc.input_file .. "';\n"
+  script = script .. "</script>"
+
+  local tmpfile = os.tmpname() .. ".html"
+  local f = assert(io.open(tmpfile, "w"))
+  f:write(script)
+  f:close()
+
+  quarto.doc.include_file("in-header", tmpfile)
   return doc
 end


### PR DESCRIPTION
This Pull Request follows PR #22, which was a bugfix pull request. It therefore includes all the commits proposed in that PR.

The present PR is a feature / UI improvement that makes the save and copy actions discoverable: a floating toolbar slides in from the bottom of the presentation whenever an editable element is modified, so users no longer need to know about the hidden buttons in the Tools menu.

## Problem

The "Save Edits" and "Copy to clipboard" actions are hidden inside the Tools menu — the user has to know they exist. There is no visual feedback indicating that unsaved modifications are pending.

## Solution

Adds a non-intrusive floating toolbar that slides in from the bottom of the presentation whenever an editable element is modified (drag, resize, or text size / layout edit).

The toolbar is only shown when modifications are actually made — it never appears if no `{.editable}` elements are present in the document (this is guaranteed by the conditional injection introduced in PR #22: the JS is not even loaded when there are no editable elements).

The toolbar shows:
- An animated yellow dot and "unsaved changes" label while modifications are pending
- A "📋 Copy to clipboard" button
- A "💾 Save edits" button
- A × button for manual dismissal

After a successful action:
- **Save**: dot turns green, label becomes "downloaded! → replace your original .qmd if satisfied", toolbar slides out after 3.5s
- **Copy**: dot turns green, label becomes "copied! → paste into your .qmd to apply changes", toolbar slides out after 3.5s

## Changes

- `_extensions/editable/editable.js` — floating toolbar IIFE + hooks into drag, resize, text edit, save and copy actions

## Related

Complements #8 (clipboard support added in PR #22).

See annotated screenshot taken during testing / development : 

<img width="1547" height="1013" alt="image" src="https://github.com/user-attachments/assets/ecffcd67-4c2c-43a2-abf5-45b830ee900c" />
