### PR TITLE
fix: add defensive null checks for global variables

### DIFF
--- a/_extensions/editable/src/arrows.js
+++ b/_extensions/editable/src/arrows.js
@@ -970,6 +970,7 @@ function createArrowHandle(arrowData, position) {
 
   const onDrag = (e) => {
     if (!isDragging) return;
+    if (!arrowData.element) return;
 
     const rect = arrowData.element.getBoundingClientRect();
     const scale = cachedScale;

--- a/_extensions/editable/src/main.js
+++ b/_extensions/editable/src/main.js
@@ -258,6 +258,7 @@ function readIndexQmd() {
  * @returns {string} Filename from injected global
  */
 function getEditableFilename() {
+  if (!window._input_filename) return 'untitled.qmd';
   return window._input_filename.split(/[/\\]/).pop();
 }
 

--- a/_extensions/editable/src/utils.js
+++ b/_extensions/editable/src/utils.js
@@ -120,6 +120,7 @@ export function getOriginalEditableDivs() {
  * @returns {number} Horizontal slide index
  */
 export function getCurrentSlideIndex() {
+  if (typeof Reveal === 'undefined') return 0;
   const indices = Reveal.getIndices();
   return indices.h;
 }
@@ -139,6 +140,7 @@ export function getCurrentSlide() {
  * @returns {boolean} True if first slide lacks an h2 heading
  */
 export function hasTitleSlide() {
+  if (typeof Reveal === 'undefined') return false;
   const firstSlide = Reveal.getSlide(0);
   if (!firstSlide) return false;
   // Title slides typically have an h1 with the title, not an h2


### PR DESCRIPTION
## Bug
https://github.com/EmilHvitfeldt/quarto-revealjs-editable/issues/83 — Several places in the source assume global variables exist without null checks, causing uncaught runtime errors that break the editor.

## Fix
Three guards, matching the locations described in the issue:

1. **`main.js` — `getEditableFilename()`**: Return `'untitled.qmd'` when `window._input_filename` is undefined instead of throwing on `.split()`
2. **`utils.js` — `getCurrentSlideIndex()` and `hasTitleSlide()`**: Check `typeof Reveal === 'undefined'` before accessing `Reveal.getIndices()` / `Reveal.getSlide()`, returning safe defaults (`0` / `false`)
3. **`arrows.js` — `onDrag()`**: Guard against null `arrowData.element` before calling `getBoundingClientRect()` (element may have been removed)

## Testing
Verified each guard handles the undefined case gracefully without breaking the normal flow when globals are present.

Happy to address any feedback.

Greetings, saschabuehrle