### PR TITLE
docs: add pre/post-render hooks to copy extensions

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,3 @@
 /.quarto/
 **/*.quarto_ipynb
+/_extensions/

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -1,6 +1,10 @@
 project:
   type: website
   output-dir: _site
+  pre-render:
+    - "cp -r ../_extensions ."
+  post-render:
+    - "rm -rf _extensions"
 
 website:
   title: "Editable Extension"


### PR DESCRIPTION
Add pre-render and post-render project hooks in `docs/_quarto.yml` to copy `_extensions/` into the docs directory before rendering and remove it afterwards. Add `/_extensions/` to `docs/.gitignore` to prevent accidental commits of the transient copy.

I'm working on running `quarto render` on all extensions listed on <https://github.com/mcanouil/quarto-extensions>.
Doing so, your extension was failing because the extension was not in the docs/ project.

- https://github.com/mcanouil/quarto-extensions/tree/quarto-tests/logs/emilhvitfeldt/quarto-revealjs-editable

To avoid duplicating/maintaining a copy, this PR adds a transient copy via pre/post-render script.
You might want to change the `.gitignore` exclusion if you need an external `_extensions`.
