### PR TITLE
Fix race condition in Quill init and use global click-outside handler for arrows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,11 @@ All notable changes to the quarto-revealjs-editable extension will be documented
   - Brand colors saved as `{{< brand color name >}}` shortcodes in arrow color attribute
   - Drag arrows by their body to move entire arrow while preserving shape
 
+### Fixed
+
+- **Race condition in Quill initialization** - Added guards to prevent duplicate initialization when `initializeQuillForElement` is called multiple times for the same element before first call completes (#85)
+- **Arrow click-outside handler performance** - Changed from per-arrow click handlers to a single global handler, eliminating redundant event listeners (#60)
+
 ---
 
 ## [6.0.0] - 2026-03-16

--- a/_extensions/editable/editable.js
+++ b/_extensions/editable/editable.js
@@ -396,11 +396,25 @@ var EditableModule = (() => {
     return quillLoading;
   }
   var quillInstances = /* @__PURE__ */ new Map();
+  var initializingElements = /* @__PURE__ */ new Set();
   async function initializeQuillForElement(element) {
     if (element.tagName.toLowerCase() !== "div")
       return null;
     if (quillInstances.has(element))
       return quillInstances.get(element);
+    if (initializingElements.has(element)) {
+      await new Promise((resolve) => {
+        const check = () => {
+          if (quillInstances.has(element))
+            resolve();
+          else
+            setTimeout(check, 10);
+        };
+        check();
+      });
+      return quillInstances.get(element);
+    }
+    initializingElements.add(element);
     try {
       let createColorHandler = function(picker, formatName) {
         return function(value) {
@@ -485,9 +499,11 @@ var EditableModule = (() => {
         quillData.isDirty = true;
       });
       quillInstances.set(element, quillData);
+      initializingElements.delete(element);
       return quillData;
     } catch (err) {
       console.error("Failed to initialize Quill for element:", err);
+      initializingElements.delete(element);
       return null;
     }
   }

--- a/_extensions/editable/editable.js
+++ b/_extensions/editable/editable.js
@@ -1373,6 +1373,7 @@ var EditableModule = (() => {
     return confirmed;
   }
   var activeArrow = null;
+  var globalClickOutsideHandlerRegistered = false;
   var arrowControlRefs = {
     colorPicker: null,
     widthInput: null,
@@ -1975,10 +1976,10 @@ var EditableModule = (() => {
     updateArrowPath(arrowData);
     updateArrowHandles(arrowData);
     setActiveArrow(arrowData);
-    if (!container._clickOutsideHandler) {
-      container._clickOutsideHandler = true;
+    if (!globalClickOutsideHandlerRegistered) {
+      globalClickOutsideHandlerRegistered = true;
       document.addEventListener("click", (e) => {
-        if (!e.target.closest(".editable-arrow-container") && !e.target.closest(".editable-toolbar") && activeArrow === arrowData) {
+        if (activeArrow && !e.target.closest(".editable-arrow-container") && !e.target.closest(".editable-toolbar")) {
           setActiveArrow(null);
         }
       });

--- a/_extensions/editable/src/arrows.js
+++ b/_extensions/editable/src/arrows.js
@@ -131,6 +131,9 @@ export async function showArrowExtensionWarning() {
 /** @type {Object|null} Currently selected arrow data */
 let activeArrow = null;
 
+/** @type {boolean} Whether the global click-outside handler has been registered */
+let globalClickOutsideHandlerRegistered = false;
+
 /** @type {Object} Cached references to arrow control DOM elements */
 const arrowControlRefs = {
   colorPicker: null,
@@ -908,12 +911,13 @@ export function createArrowElement(arrowData) {
 
   setActiveArrow(arrowData);
 
-  if (!container._clickOutsideHandler) {
-    container._clickOutsideHandler = true;
+  // Register global click-outside handler once (not per-arrow)
+  if (!globalClickOutsideHandlerRegistered) {
+    globalClickOutsideHandlerRegistered = true;
     document.addEventListener("click", (e) => {
-      if (!e.target.closest(".editable-arrow-container") &&
-          !e.target.closest(".editable-toolbar") &&
-          activeArrow === arrowData) {
+      if (activeArrow &&
+          !e.target.closest(".editable-arrow-container") &&
+          !e.target.closest(".editable-toolbar")) {
         setActiveArrow(null);
       }
     });

--- a/_extensions/editable/src/quill.js
+++ b/_extensions/editable/src/quill.js
@@ -54,6 +54,9 @@ export function loadQuill() {
  */
 export const quillInstances = new Map();
 
+/** @type {Set<HTMLElement>} Elements currently being initialized (race condition guard) */
+const initializingElements = new Set();
+
 /**
  * Initialize Quill editor for an editable div element.
  * Called at page load to prevent text shifting when entering edit mode.
@@ -66,6 +69,20 @@ export async function initializeQuillForElement(element) {
 
   // Skip if already initialized
   if (quillInstances.has(element)) return quillInstances.get(element);
+
+  // Guard against race conditions - wait for existing initialization
+  if (initializingElements.has(element)) {
+    await new Promise(resolve => {
+      const check = () => {
+        if (quillInstances.has(element)) resolve();
+        else setTimeout(check, 10);
+      };
+      check();
+    });
+    return quillInstances.get(element);
+  }
+
+  initializingElements.add(element);
 
   try {
     await loadQuill();
@@ -182,10 +199,12 @@ export async function initializeQuillForElement(element) {
     });
 
     quillInstances.set(element, quillData);
+    initializingElements.delete(element);
 
     return quillData;
   } catch (err) {
     console.error("Failed to initialize Quill for element:", err);
+    initializingElements.delete(element);
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- Fix race condition in Quill initialization by adding guards to prevent duplicate initialization when `initializeQuillForElement` is called multiple times for the same element
- Use a single global click-outside handler for arrows instead of per-arrow handlers, eliminating redundant event listeners

Closes #85
Closes #60