### PR TITLE
Dedup modify-mode classifier boilerplate (PR 1 / mechanical)

### DIFF
--- a/_extensions/editable/editable.js
+++ b/_extensions/editable/editable.js
@@ -2995,6 +2995,9 @@ var EditableModule = (() => {
   function round(n) {
     return Math.round(n * 10) / 10;
   }
+  function escapeRegex(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
   function debug(...args) {
     if (typeof window !== "undefined" && window.EDITABLE_DEBUG) {
       console.debug("[editable]", ...args);
@@ -16293,9 +16296,6 @@ ${fence}`;
       return chunks.join("");
     }
   });
-  function escapeRegex(s) {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  }
   function makeAbsoluteBlockRegex(left, top, width, height) {
     const vals = [
       `left=${Math.round(left)}px`,
@@ -16386,21 +16386,31 @@ ${fence}`;
     { label: "figure", selectors: ["div.quarto-figure"], capabilities: ["move", "resize"], lockDims: true, quill: false, display: null },
     { label: "table", selectors: ["table"], capabilities: ["move"], lockDims: true, quill: false, display: "table" }
   ];
-  function lockNaturalDimensions(el, displayOverride) {
+  function captureSlideRelativePosition(el, { rectSource } = {}) {
     const slideEl = el.closest("section");
     const scale = getSlideScale();
-    const elRect = el.getBoundingClientRect();
+    const rect = (rectSource ?? el).getBoundingClientRect();
     const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-    const naturalW = elRect.width / scale;
-    const naturalH = elRect.height / scale;
+    return {
+      left: (rect.left - slideRect.left) / scale,
+      top: (rect.top - slideRect.top) / scale,
+      width: rect.width / scale,
+      height: rect.height / scale,
+      scale,
+      slideEl
+    };
+  }
+  function lockNaturalDimensions(el, displayOverride) {
+    const scale = getSlideScale();
+    const elRect = el.getBoundingClientRect();
     const cs = window.getComputedStyle(el);
     el.style.paddingLeft = cs.paddingLeft;
     el.style.paddingRight = cs.paddingRight;
     el.style.paddingTop = cs.paddingTop;
     el.style.paddingBottom = cs.paddingBottom;
     el.style.margin = "0";
-    el.style.width = naturalW + "px";
-    el.style.height = naturalH + "px";
+    el.style.width = elRect.width / scale + "px";
+    el.style.height = elRect.height / scale + "px";
     if (displayOverride)
       el.style.display = displayOverride;
   }
@@ -16830,6 +16840,31 @@ ${fence}`;
     lines.splice(block.endLine + 1, 0, ":::");
     lines.splice(block.startLine, 0, `::: {${attrs}}`);
   }
+  function sortByIndexAttr(els, attrName) {
+    els.sort(
+      (a, b) => parseInt(a.dataset[attrName] ?? "0", 10) - parseInt(b.dataset[attrName] ?? "0", 10)
+    );
+  }
+  function forEachInReverse(items, fn) {
+    for (let i = items.length - 1; i >= 0; i--)
+      fn(items[i], i);
+  }
+  function groupModifiedElementsByChunk(els, text) {
+    const chunks = splitIntoSlideChunks(text);
+    const byChunk = /* @__PURE__ */ new Map();
+    for (const el of els) {
+      if (!editableRegistry.has(el))
+        continue;
+      const slideIndex = parseInt(el.dataset.editableModifiedSlide ?? "0", 10);
+      const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
+      if (chunkIndex >= chunks.length)
+        continue;
+      if (!byChunk.has(chunkIndex))
+        byChunk.set(chunkIndex, []);
+      byChunk.get(chunkIndex).push(el);
+    }
+    return { chunks, byChunk };
+  }
   function buildFenceLineWithAbsolute(originalLine, dims) {
     const match2 = originalLine.match(/^(:{3,})\s*(?:\{([^}]*)\})?\s*$/);
     if (!match2)
@@ -16890,12 +16925,7 @@ ${fence}`;
       const slideIndex = Reveal.getState().indexh;
       div.dataset.editableModifiedFence = "true";
       div.dataset.editableModifiedSlide = String(slideIndex);
-      const slideEl = div.closest("section");
-      const scale = getSlideScale();
-      const divRect = div.getBoundingClientRect();
-      const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-      const origLeft = (divRect.left - slideRect.left) / scale;
-      const origTop = (divRect.top - slideRect.top) / scale;
+      const { left: origLeft, top: origTop } = captureSlideRelativePosition(div);
       if (div.dataset.editableModifiedFenceType === "columns") {
         setCapabilityOverride(div, ["move", "resize", "rotate"]);
         const naturalWidth = div.offsetWidth;
@@ -16914,19 +16944,7 @@ ${fence}`;
       );
       if (divs.length === 0)
         return text;
-      const chunks = splitIntoSlideChunks(text);
-      const byChunk = /* @__PURE__ */ new Map();
-      for (const div of divs) {
-        if (!editableRegistry.has(div))
-          continue;
-        const slideIndex = parseInt(div.dataset.editableModifiedSlide ?? "0", 10);
-        const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-        if (chunkIndex >= chunks.length)
-          continue;
-        if (!byChunk.has(chunkIndex))
-          byChunk.set(chunkIndex, []);
-        byChunk.get(chunkIndex).push(div);
-      }
+      const { chunks, byChunk } = groupModifiedElementsByChunk(divs, text);
       for (const [chunkIndex, chunkDivs] of byChunk) {
         const fencedOpens = parseFencedDivOpens(chunks[chunkIndex]);
         const ops = [];
@@ -17034,12 +17052,7 @@ ${fence}`;
     },
     activate(p) {
       const slideIndex = Reveal.getState().indexh;
-      const slideEl = p.closest("section");
-      const scale = getSlideScale();
-      const pRect = p.getBoundingClientRect();
-      const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-      const origLeft = (pRect.left - slideRect.left) / scale;
-      const origTop = (pRect.top - slideRect.top) / scale;
+      const { left: origLeft, top: origTop } = captureSlideRelativePosition(p);
       p.dataset.editableModifiedParagraph = "true";
       p.dataset.editableModifiedSlide = String(slideIndex);
       initializeQuillForElement(p);
@@ -17052,30 +17065,15 @@ ${fence}`;
       );
       if (paras.length === 0)
         return text;
-      const chunks = splitIntoSlideChunks(text);
-      const byChunk = /* @__PURE__ */ new Map();
-      for (const p of paras) {
-        if (!editableRegistry.has(p))
-          continue;
-        const slideIndex = parseInt(p.dataset.editableModifiedSlide ?? "0", 10);
-        const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-        if (chunkIndex >= chunks.length)
-          continue;
-        if (!byChunk.has(chunkIndex))
-          byChunk.set(chunkIndex, []);
-        byChunk.get(chunkIndex).push(p);
-      }
+      const { chunks, byChunk } = groupModifiedElementsByChunk(paras, text);
       for (const [chunkIndex, chunkParas] of byChunk) {
-        chunkParas.sort(
-          (a, b) => parseInt(a.dataset.editableModifiedParagraphIdx ?? "0", 10) - parseInt(b.dataset.editableModifiedParagraphIdx ?? "0", 10)
-        );
+        sortByIndexAttr(chunkParas, "editableModifiedParagraphIdx");
         const paraBlocks = extractParagraphBlocks(chunks[chunkIndex]);
         const lines = chunks[chunkIndex].split("\n");
-        for (let i = chunkParas.length - 1; i >= 0; i--) {
-          const p = chunkParas[i];
+        forEachInReverse(chunkParas, (p) => {
           const paraIdx = parseInt(p.dataset.editableModifiedParagraphIdx ?? "0", 10);
           if (paraIdx >= paraBlocks.length)
-            continue;
+            return;
           const block = paraBlocks[paraIdx];
           const dims = editableRegistry.get(p).toDimensions();
           const content = p.querySelector(".ql-editor") ? elementToText(p) : block.text;
@@ -17088,7 +17086,7 @@ ${fence}`;
             content,
             ":::"
           );
-        }
+        });
         chunks[chunkIndex] = lines.join("\n");
       }
       return chunks.join("");
@@ -17169,23 +17167,8 @@ ${fence}`;
       },
       activate(el) {
         const slideIndex = Reveal.getState().indexh;
-        const slideEl = el.closest("section");
-        const scale = getSlideScale();
-        const elRect = el.getBoundingClientRect();
-        const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-        const origLeft = (elRect.left - slideRect.left) / scale;
-        const origTop = (elRect.top - slideRect.top) / scale;
-        const cs = window.getComputedStyle(el);
-        const naturalW = elRect.width / scale;
-        const naturalH = elRect.height / scale;
-        el.style.paddingLeft = cs.paddingLeft;
-        el.style.paddingRight = cs.paddingRight;
-        el.style.paddingTop = cs.paddingTop;
-        el.style.paddingBottom = cs.paddingBottom;
-        el.style.margin = "0";
-        el.style.width = naturalW + "px";
-        el.style.height = naturalH + "px";
-        el.style.display = "block";
+        const { left: origLeft, top: origTop } = captureSlideRelativePosition(el);
+        lockNaturalDimensions(el, "block");
         el.dataset[activeAttr] = "true";
         el.dataset.editableModifiedSlide = String(slideIndex);
         setCapabilityOverride(el, ["move", "resize"]);
@@ -17199,30 +17182,15 @@ ${fence}`;
         );
         if (els.length === 0)
           return text;
-        const chunks = splitIntoSlideChunks(text);
-        const byChunk = /* @__PURE__ */ new Map();
-        for (const el of els) {
-          if (!editableRegistry.has(el))
-            continue;
-          const slideIndex = parseInt(el.dataset.editableModifiedSlide ?? "0", 10);
-          const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-          if (chunkIndex >= chunks.length)
-            continue;
-          if (!byChunk.has(chunkIndex))
-            byChunk.set(chunkIndex, []);
-          byChunk.get(chunkIndex).push(el);
-        }
+        const { chunks, byChunk } = groupModifiedElementsByChunk(els, text);
         for (const [chunkIndex, chunkEls] of byChunk) {
-          chunkEls.sort(
-            (a, b) => parseInt(a.dataset[idxAttr] ?? "0", 10) - parseInt(b.dataset[idxAttr] ?? "0", 10)
-          );
+          sortByIndexAttr(chunkEls, idxAttr);
           const blocks = extractBlocksStartingWith(chunks[chunkIndex], testLine);
           const lines = chunks[chunkIndex].split("\n");
-          for (let i = chunkEls.length - 1; i >= 0; i--) {
-            const el = chunkEls[i];
+          forEachInReverse(chunkEls, (el) => {
             const elIdx = parseInt(el.dataset[idxAttr] ?? "0", 10);
             if (elIdx >= blocks.length)
-              continue;
+              return;
             const block = blocks[elIdx];
             const dims = editableRegistry.get(el).toDimensions();
             const attrs = buildAbsoluteAttrString(dims);
@@ -17234,7 +17202,7 @@ ${fence}`;
               block.text,
               ":::"
             );
-          }
+          });
           chunks[chunkIndex] = lines.join("\n");
         }
         return chunks.join("");
@@ -17588,23 +17556,8 @@ ${fence}`;
     },
     activate(el) {
       const slideIndex = Reveal.getState().indexh;
-      const slideEl = el.closest("section");
-      const scale = getSlideScale();
-      const elRect = el.getBoundingClientRect();
-      const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-      const origLeft = (elRect.left - slideRect.left) / scale;
-      const origTop = (elRect.top - slideRect.top) / scale;
-      const cs = window.getComputedStyle(el);
-      const naturalW = elRect.width / scale;
-      const naturalH = elRect.height / scale;
-      el.style.paddingLeft = cs.paddingLeft;
-      el.style.paddingRight = cs.paddingRight;
-      el.style.paddingTop = cs.paddingTop;
-      el.style.paddingBottom = cs.paddingBottom;
-      el.style.margin = "0";
-      el.style.width = naturalW + "px";
-      el.style.height = naturalH + "px";
-      el.style.display = "block";
+      const { left: origLeft, top: origTop } = captureSlideRelativePosition(el);
+      lockNaturalDimensions(el, "block");
       el.dataset.editableModifiedCode = "true";
       el.dataset.editableModifiedSlide = String(slideIndex);
       setCapabilityOverride(el, ["move", "resize"]);
@@ -17617,39 +17570,24 @@ ${fence}`;
       );
       if (els.length === 0)
         return text;
-      const chunks = splitIntoSlideChunks(text);
-      const byChunk = /* @__PURE__ */ new Map();
-      for (const el of els) {
-        if (!editableRegistry.has(el))
-          continue;
-        const slideIndex = parseInt(el.dataset.editableModifiedSlide ?? "0", 10);
-        const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-        if (chunkIndex >= chunks.length)
-          continue;
-        if (!byChunk.has(chunkIndex))
-          byChunk.set(chunkIndex, []);
-        byChunk.get(chunkIndex).push(el);
-      }
+      const { chunks, byChunk } = groupModifiedElementsByChunk(els, text);
       for (const [chunkIndex, chunkEls] of byChunk) {
-        chunkEls.sort(
-          (a, b) => parseInt(a.dataset.editableModifiedCodeIdx ?? "0", 10) - parseInt(b.dataset.editableModifiedCodeIdx ?? "0", 10)
-        );
+        sortByIndexAttr(chunkEls, "editableModifiedCodeIdx");
         const blocks = extractCodeBlocks(chunks[chunkIndex]);
         const lines = chunks[chunkIndex].split("\n");
-        for (let i = chunkEls.length - 1; i >= 0; i--) {
-          const el = chunkEls[i];
+        forEachInReverse(chunkEls, (el) => {
           const codeIdx = parseInt(el.dataset.editableModifiedCodeIdx ?? "0", 10);
           if (codeIdx >= blocks.length)
-            continue;
+            return;
           const expectedFirst = (el.dataset.editableModifiedCodeFirstLine ?? "").trim();
           const actualFirst = (blocks[codeIdx].firstCodeLine ?? "").trim();
           if (expectedFirst && actualFirst && expectedFirst !== actualFirst)
-            continue;
+            return;
           const block = blocks[codeIdx];
           const dims = editableRegistry.get(el).toDimensions();
           const attrs = buildAbsoluteAttrString(dims);
           wrapLinesWithAbsoluteFence(lines, block, attrs);
-        }
+        });
         chunks[chunkIndex] = lines.join("\n");
       }
       return chunks.join("");
@@ -17773,23 +17711,8 @@ ${fence}`;
     },
     activate(el) {
       const slideIndex = Reveal.getState().indexh;
-      const slideEl = el.closest("section");
-      const scale = getSlideScale();
-      const elRect = el.getBoundingClientRect();
-      const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-      const origLeft = (elRect.left - slideRect.left) / scale;
-      const origTop = (elRect.top - slideRect.top) / scale;
-      const cs = window.getComputedStyle(el);
-      const naturalW = elRect.width / scale;
-      const naturalH = elRect.height / scale;
-      el.style.paddingLeft = cs.paddingLeft;
-      el.style.paddingRight = cs.paddingRight;
-      el.style.paddingTop = cs.paddingTop;
-      el.style.paddingBottom = cs.paddingBottom;
-      el.style.margin = "0";
-      el.style.width = naturalW + "px";
-      el.style.height = naturalH + "px";
-      el.style.display = "block";
+      const { left: origLeft, top: origTop } = captureSlideRelativePosition(el);
+      lockNaturalDimensions(el, "block");
       el.dataset.editableModifiedCell = "true";
       el.dataset.editableModifiedSlide = String(slideIndex);
       setCapabilityOverride(el, ["move", "resize"]);
@@ -17802,27 +17725,12 @@ ${fence}`;
       );
       if (els.length === 0)
         return text;
-      const chunks = splitIntoSlideChunks(text);
-      const byChunk = /* @__PURE__ */ new Map();
-      for (const el of els) {
-        if (!editableRegistry.has(el))
-          continue;
-        const slideIndex = parseInt(el.dataset.editableModifiedSlide ?? "0", 10);
-        const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-        if (chunkIndex >= chunks.length)
-          continue;
-        if (!byChunk.has(chunkIndex))
-          byChunk.set(chunkIndex, []);
-        byChunk.get(chunkIndex).push(el);
-      }
+      const { chunks, byChunk } = groupModifiedElementsByChunk(els, text);
       for (const [chunkIndex, chunkEls] of byChunk) {
-        chunkEls.sort(
-          (a, b) => parseInt(a.dataset.editableModifiedCellIdx ?? "0", 10) - parseInt(b.dataset.editableModifiedCellIdx ?? "0", 10)
-        );
+        sortByIndexAttr(chunkEls, "editableModifiedCellIdx");
         const execChunks = extractExecutableChunks(chunks[chunkIndex]);
         const lines = chunks[chunkIndex].split("\n");
-        for (let i = chunkEls.length - 1; i >= 0; i--) {
-          const el = chunkEls[i];
+        forEachInReverse(chunkEls, (el) => {
           const cellLabel = el.dataset.editableModifiedCellLabel || "";
           const cellFirstLine = (el.dataset.editableModifiedCellFirstLine ?? "").trim();
           const cellIdx = parseInt(el.dataset.editableModifiedCellIdx ?? "-1", 10);
@@ -17838,11 +17746,11 @@ ${fence}`;
             }
           }
           if (!target)
-            continue;
+            return;
           const dims = editableRegistry.get(el).toDimensions();
           const attrs = buildAbsoluteAttrString(dims);
           wrapLinesWithAbsoluteFence(lines, target, attrs);
-        }
+        });
         chunks[chunkIndex] = lines.join("\n");
       }
       return chunks.join("");
@@ -17942,27 +17850,12 @@ ${fence}`;
       );
       if (imgs.length === 0)
         return text;
-      const chunks = splitIntoSlideChunks(text);
-      const byChunk = /* @__PURE__ */ new Map();
-      for (const img of imgs) {
-        if (!editableRegistry.has(img))
-          continue;
-        const slideIndex = parseInt(img.dataset.editableModifiedSlide ?? "0", 10);
-        const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-        if (chunkIndex >= chunks.length)
-          continue;
-        if (!byChunk.has(chunkIndex))
-          byChunk.set(chunkIndex, []);
-        byChunk.get(chunkIndex).push(img);
-      }
+      const { chunks, byChunk } = groupModifiedElementsByChunk(imgs, text);
       for (const [chunkIndex, chunkImgs] of byChunk) {
-        chunkImgs.sort(
-          (a, b) => parseInt(a.dataset.editableModifiedChunkFigExecIdx ?? "0", 10) - parseInt(b.dataset.editableModifiedChunkFigExecIdx ?? "0", 10)
-        );
+        sortByIndexAttr(chunkImgs, "editableModifiedChunkFigExecIdx");
         const execChunks = extractExecutableChunks(chunks[chunkIndex]);
         const lines = chunks[chunkIndex].split("\n");
-        for (let i = chunkImgs.length - 1; i >= 0; i--) {
-          const img = chunkImgs[i];
+        forEachInReverse(chunkImgs, (img) => {
           const label = img.dataset.editableModifiedChunkFigLabel || "";
           const firstLine = (img.dataset.editableModifiedChunkFigFirstLine ?? "").trim();
           const execIdx = parseInt(img.dataset.editableModifiedChunkFigExecIdx ?? "-1", 10);
@@ -17978,11 +17871,11 @@ ${fence}`;
             }
           }
           if (!target)
-            continue;
+            return;
           const dims = editableRegistry.get(img).toDimensions();
           const attrs = buildAbsoluteAttrString(dims);
           wrapLinesWithAbsoluteFence(lines, target, attrs);
-        }
+        });
         chunks[chunkIndex] = lines.join("\n");
       }
       return chunks.join("");
@@ -18167,23 +18060,9 @@ ${fence}`;
     },
     activate(el) {
       const slideIndex = Reveal.getState().indexh;
-      const slideEl = el.closest("section");
-      const scale = getSlideScale();
-      const elRect = el.getBoundingClientRect();
-      const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-      const origLeft = (elRect.left - slideRect.left) / scale;
-      const origTop = (elRect.top - slideRect.top) / scale;
-      const cs = window.getComputedStyle(el);
-      const naturalW = elRect.width / scale;
-      const naturalH = elRect.height / scale;
+      const { left: origLeft, top: origTop } = captureSlideRelativePosition(el);
       const isTable = el.tagName === "TABLE";
-      el.style.paddingLeft = cs.paddingLeft;
-      el.style.paddingRight = cs.paddingRight;
-      el.style.paddingTop = cs.paddingTop;
-      el.style.paddingBottom = cs.paddingBottom;
-      el.style.margin = "0";
-      el.style.width = naturalW + "px";
-      el.style.height = naturalH + "px";
+      lockNaturalDimensions(el);
       el.dataset.editableModifiedTable = "true";
       el.dataset.editableModifiedSlide = String(slideIndex);
       setCapabilityOverride(el, ["move"]);
@@ -18198,23 +18077,9 @@ ${fence}`;
       );
       if (els.length === 0)
         return text;
-      const chunks = splitIntoSlideChunks(text);
-      const byChunk = /* @__PURE__ */ new Map();
-      for (const el of els) {
-        if (!editableRegistry.has(el))
-          continue;
-        const slideIndex = parseInt(el.dataset.editableModifiedSlide ?? "0", 10);
-        const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-        if (chunkIndex >= chunks.length)
-          continue;
-        if (!byChunk.has(chunkIndex))
-          byChunk.set(chunkIndex, []);
-        byChunk.get(chunkIndex).push(el);
-      }
+      const { chunks, byChunk } = groupModifiedElementsByChunk(els, text);
       for (const [chunkIndex, chunkEls] of byChunk) {
-        chunkEls.sort(
-          (a, b) => parseInt(a.dataset.editableModifiedTableIdx ?? "0", 10) - parseInt(b.dataset.editableModifiedTableIdx ?? "0", 10)
-        );
+        sortByIndexAttr(chunkEls, "editableModifiedTableIdx");
         const sourceTables = extractTables(chunks[chunkIndex]);
         const lines = chunks[chunkIndex].split("\n");
         const headerCounts = /* @__PURE__ */ new Map();
@@ -18366,15 +18231,8 @@ ${fence}`;
     },
     activate(el) {
       const slideIndex = Reveal.getState().indexh;
-      const slideEl = el.closest("section");
-      const scale = getSlideScale();
-      const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
       const inner = el.querySelector(".MathJax_Display, mjx-container, .katex-display, span.math.display") ?? el;
-      const innerRect = inner.getBoundingClientRect();
-      const origLeft = (innerRect.left - slideRect.left) / scale;
-      const origTop = (innerRect.top - slideRect.top) / scale;
-      const naturalW = innerRect.width / scale;
-      const naturalH = innerRect.height / scale;
+      const { left: origLeft, top: origTop, width: naturalW, height: naturalH } = captureSlideRelativePosition(el, { rectSource: inner });
       el.style.padding = "0";
       el.style.margin = "0";
       el.style.width = naturalW + "px";
@@ -18394,23 +18252,9 @@ ${fence}`;
       );
       if (els.length === 0)
         return text;
-      const chunks = splitIntoSlideChunks(text);
-      const byChunk = /* @__PURE__ */ new Map();
-      for (const el of els) {
-        if (!editableRegistry.has(el))
-          continue;
-        const slideIndex = parseInt(el.dataset.editableModifiedSlide ?? "0", 10);
-        const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-        if (chunkIndex >= chunks.length)
-          continue;
-        if (!byChunk.has(chunkIndex))
-          byChunk.set(chunkIndex, []);
-        byChunk.get(chunkIndex).push(el);
-      }
+      const { chunks, byChunk } = groupModifiedElementsByChunk(els, text);
       for (const [chunkIndex, chunkEls] of byChunk) {
-        chunkEls.sort(
-          (a, b) => parseInt(a.dataset.editableModifiedEqIdx ?? "0", 10) - parseInt(b.dataset.editableModifiedEqIdx ?? "0", 10)
-        );
+        sortByIndexAttr(chunkEls, "editableModifiedEqIdx");
         const sourceEqs = extractDisplayEquations(chunks[chunkIndex]);
         const lines = chunks[chunkIndex].split("\n");
         const headerCounts = /* @__PURE__ */ new Map();

--- a/_extensions/editable/src/__tests__/modify-mode-helpers.test.js
+++ b/_extensions/editable/src/__tests__/modify-mode-helpers.test.js
@@ -15,7 +15,11 @@ vi.mock('../serialization.js', () => ({
   elementToText: vi.fn(),
   serializeArrowToShortcode: vi.fn(),
 }));
-vi.mock('../utils.js', () => ({ getQmdHeadingIndex: vi.fn(), getSlideScale: vi.fn() }));
+vi.mock('../utils.js', () => ({
+  getQmdHeadingIndex: vi.fn(),
+  getSlideScale: vi.fn(),
+  escapeRegex: (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+}));
 vi.mock('../colors.js', () => ({ getColorPalette: vi.fn(() => []), getBrandColorOutput: vi.fn() }));
 vi.mock('../capabilities.js', () => ({ setCapabilityOverride: vi.fn() }));
 vi.mock('../quill.js', () => ({ quillInstances: new Map(), initializeQuillForElement: vi.fn() }));
@@ -26,7 +30,15 @@ import {
   findPositionedAncestor,
   buildAbsoluteAttrString,
   wrapLinesWithAbsoluteFence,
+  sortByIndexAttr,
+  forEachInReverse,
+  captureSlideRelativePosition,
+  lockNaturalDimensions,
+  groupModifiedElementsByChunk,
 } from '../modify-mode.js';
+import { splitIntoSlideChunks } from '../serialization.js';
+import { getQmdHeadingIndex, getSlideScale } from '../utils.js';
+import { editableRegistry } from '../editable-element.js';
 
 // Tiny fake-element factory: only models classList.contains + closest, which
 // is everything the helpers under test inspect. Saves us from needing jsdom.
@@ -153,5 +165,195 @@ describe('wrapLinesWithAbsoluteFence', () => {
     const ret = wrapLinesWithAbsoluteFence(lines, { startLine: 0, endLine: 0 }, '.absolute');
     expect(ret).toBeUndefined();
     expect(lines).toEqual(['::: {.absolute}', 'x', ':::']);
+  });
+});
+
+describe('sortByIndexAttr', () => {
+  it('sorts elements ascending by parsed dataset integer', () => {
+    const els = [
+      { dataset: { idx: '2' } },
+      { dataset: { idx: '0' } },
+      { dataset: { idx: '10' } },
+      { dataset: { idx: '1' } },
+    ];
+    sortByIndexAttr(els, 'idx');
+    expect(els.map(e => e.dataset.idx)).toEqual(['0', '1', '2', '10']);
+  });
+
+  it('treats missing attr as 0', () => {
+    const els = [
+      { dataset: { idx: '3' } },
+      { dataset: {} },
+      { dataset: { idx: '1' } },
+    ];
+    sortByIndexAttr(els, 'idx');
+    expect(els.map(e => e.dataset.idx ?? 'missing')).toEqual(['missing', '1', '3']);
+  });
+});
+
+describe('forEachInReverse', () => {
+  it('invokes fn from last to first', () => {
+    const seen = [];
+    forEachInReverse(['a', 'b', 'c'], (item, i) => seen.push([item, i]));
+    expect(seen).toEqual([['c', 2], ['b', 1], ['a', 0]]);
+  });
+
+  it('keeps splice indices stable when used to mutate a parallel array', () => {
+    const lines = ['L0', 'L1', 'L2', 'L3'];
+    const items = [{ at: 0 }, { at: 2 }];
+    forEachInReverse(items, ({ at }) => lines.splice(at, 1, 'X', 'Y'));
+    // Both splices should land at their original positions, not shifted by
+    // earlier inserts.
+    expect(lines).toEqual(['X', 'Y', 'L1', 'X', 'Y', 'L3']);
+  });
+
+  it('handles empty arrays without invoking fn', () => {
+    const fn = vi.fn();
+    forEachInReverse([], fn);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe('captureSlideRelativePosition', () => {
+  beforeEach(() => {
+    getSlideScale.mockReset();
+    getSlideScale.mockReturnValue(2);
+  });
+
+  function elWith({ rect, slideRect, inner }) {
+    const slide = slideRect
+      ? { getBoundingClientRect: () => slideRect, _tag: 'section', classList: { contains: () => false } }
+      : null;
+    const el = {
+      getBoundingClientRect: () => rect,
+      _tag: 'div',
+      classList: { contains: () => false },
+      closest: (sel) => (sel === 'section' ? slide : null),
+    };
+    if (inner) el._inner = inner;
+    return el;
+  }
+
+  it('returns scaled slide-relative position', () => {
+    const el = elWith({
+      rect: { left: 200, top: 300, width: 400, height: 200 },
+      slideRect: { left: 100, top: 100 },
+    });
+    const out = captureSlideRelativePosition(el);
+    expect(out.left).toBe(50);    // (200 - 100) / 2
+    expect(out.top).toBe(100);    // (300 - 100) / 2
+    expect(out.width).toBe(200);  // 400 / 2
+    expect(out.height).toBe(100); // 200 / 2
+    expect(out.scale).toBe(2);
+  });
+
+  it('falls back to {0,0} slideRect when there is no section ancestor', () => {
+    const el = elWith({
+      rect: { left: 50, top: 80, width: 100, height: 40 },
+      slideRect: null,
+    });
+    const out = captureSlideRelativePosition(el);
+    expect(out.left).toBe(25);
+    expect(out.top).toBe(40);
+  });
+
+  it('measures from rectSource when provided (equation inner-math anchor)', () => {
+    const inner = {
+      getBoundingClientRect: () => ({ left: 250, top: 350, width: 80, height: 30 }),
+    };
+    const el = elWith({
+      rect: { left: 200, top: 300, width: 400, height: 200 },
+      slideRect: { left: 100, top: 100 },
+    });
+    const out = captureSlideRelativePosition(el, { rectSource: inner });
+    expect(out.left).toBe(75);   // (250 - 100) / 2
+    expect(out.top).toBe(125);   // (350 - 100) / 2
+    expect(out.width).toBe(40);
+    expect(out.height).toBe(15);
+  });
+});
+
+describe('lockNaturalDimensions', () => {
+  beforeEach(() => {
+    getSlideScale.mockReset();
+    getSlideScale.mockReturnValue(2);
+    // jsdom-free getComputedStyle stub
+    if (typeof globalThis.window === 'undefined') globalThis.window = {};
+    globalThis.window.getComputedStyle = () => ({
+      paddingLeft: '4px',
+      paddingRight: '4px',
+      paddingTop: '2px',
+      paddingBottom: '2px',
+    });
+  });
+
+  it('writes scaled width/height and copied padding, zeroes margin', () => {
+    const style = {};
+    const el = {
+      getBoundingClientRect: () => ({ width: 400, height: 200 }),
+      style,
+    };
+    lockNaturalDimensions(el);
+    expect(style.width).toBe('200px');
+    expect(style.height).toBe('100px');
+    expect(style.paddingLeft).toBe('4px');
+    expect(style.paddingTop).toBe('2px');
+    expect(style.margin).toBe('0');
+    expect(style.display).toBeUndefined();
+  });
+
+  it('sets display when displayOverride is passed', () => {
+    const style = {};
+    const el = {
+      getBoundingClientRect: () => ({ width: 100, height: 50 }),
+      style,
+    };
+    lockNaturalDimensions(el, 'block');
+    expect(style.display).toBe('block');
+  });
+});
+
+describe('groupModifiedElementsByChunk', () => {
+  beforeEach(() => {
+    splitIntoSlideChunks.mockReset();
+    getQmdHeadingIndex.mockReset();
+    splitIntoSlideChunks.mockReturnValue(['preamble', '## A\n', '## B\n', '## C\n']);
+    // slide index N → chunk N+1 (i.e. getQmdHeadingIndex(N) === N)
+    getQmdHeadingIndex.mockImplementation((n) => n);
+    // Pretend all elements are in the registry.
+    editableRegistry.has = () => true;
+  });
+
+  function modEl(slide) {
+    return { dataset: { editableModifiedSlide: String(slide) } };
+  }
+
+  it('groups elements by their source-chunk index', () => {
+    const a = modEl(0); // chunk 1
+    const b = modEl(0); // chunk 1
+    const c = modEl(1); // chunk 2
+    const { chunks, byChunk } = groupModifiedElementsByChunk([a, b, c], 'ignored');
+    expect(chunks).toHaveLength(4);
+    expect(byChunk.get(1)).toEqual([a, b]);
+    expect(byChunk.get(2)).toEqual([c]);
+  });
+
+  it('skips elements not in editableRegistry', () => {
+    editableRegistry.has = (el) => el !== 'orphan';
+    const a = modEl(0);
+    const { byChunk } = groupModifiedElementsByChunk(['orphan', a], 'ignored');
+    expect(byChunk.get(1)).toEqual([a]);
+  });
+
+  it('skips elements whose chunk index runs past the chunk array', () => {
+    const a = modEl(99);
+    const { byChunk } = groupModifiedElementsByChunk([a], 'ignored');
+    expect(byChunk.size).toBe(0);
+  });
+
+  it('treats missing slide attr as slide 0', () => {
+    const a = { dataset: {} };
+    const { byChunk } = groupModifiedElementsByChunk([a], 'ignored');
+    expect(byChunk.get(1)).toEqual([a]);
   });
 });

--- a/_extensions/editable/src/__tests__/modify-mode-positioned.test.js
+++ b/_extensions/editable/src/__tests__/modify-mode-positioned.test.js
@@ -4,7 +4,10 @@ vi.mock('../editable-element.js', () => ({ editableRegistry: { has: () => false,
 vi.mock('../serialization.js', () => ({
   splitIntoSlideChunks: vi.fn(),
 }));
-vi.mock('../utils.js', () => ({ getQmdHeadingIndex: vi.fn() }));
+vi.mock('../utils.js', () => ({
+  getQmdHeadingIndex: vi.fn(),
+  escapeRegex: (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+}));
 
 import {
   parseAbsoluteFences,

--- a/_extensions/editable/src/modify-mode-positioned.js
+++ b/_extensions/editable/src/modify-mode-positioned.js
@@ -21,7 +21,7 @@
 
 import { editableRegistry } from './editable-element.js';
 import { splitIntoSlideChunks } from './serialization.js';
-import { getQmdHeadingIndex } from './utils.js';
+import { getQmdHeadingIndex, escapeRegex } from './utils.js';
 
 /* eslint-env browser */
 /* global Reveal */
@@ -141,10 +141,6 @@ export const Anchors = {
     test: (_f, i) => i === index,
   }),
 };
-
-function escapeRegex(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 /**
  * Poll until `el` appears in `editableRegistry`, then place the wrapping

--- a/_extensions/editable/src/modify-mode.js
+++ b/_extensions/editable/src/modify-mode.js
@@ -40,7 +40,7 @@ import {
   elementToText,
   serializeArrowToShortcode,
 } from './serialization.js';
-import { getQmdHeadingIndex, getSlideScale } from './utils.js';
+import { getQmdHeadingIndex, getSlideScale, escapeRegex } from './utils.js';
 import { getColorPalette, getBrandColorOutput } from './colors.js';
 import { setCapabilityOverride } from './capabilities.js';
 import { createArrowElement, setActiveArrow } from './arrows.js';
@@ -408,10 +408,6 @@ ModifyModeClassifier.register({
 // two element types onto that factory.
 // ---------------------------------------------------------------------------
 
-function escapeRegex(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 /**
  * Build a regex that matches a {.absolute ...} attribute block containing
  * all four original position values in any order.
@@ -530,28 +526,53 @@ const TYPED_INNER_CONFIGS = [
 ];
 
 /**
- * Lock the element's natural width/height + padding so it doesn't collapse
- * when reparented into the inline-block `editable-container`. Mirrors the
- * pattern used by the list/blockquote first-activation classifiers.
+ * Read an element's position relative to its slide, scaled out of CSS-pixel
+ * space so the numbers match the element-space coordinates that QMD source
+ * uses. Pass `rectSource` to measure from a nested node (e.g. the rendered
+ * math container inside an equation `<p>`) while still anchoring against the
+ * outer element's slide.
+ *
+ * Returns `{ left, top, width, height, scale, slideEl }`.
  */
-function lockNaturalDimensions(el, displayOverride) {
+export function captureSlideRelativePosition(el, { rectSource } = {}) {
   const slideEl = el.closest('section');
   const scale = getSlideScale();
-  const elRect = el.getBoundingClientRect();
+  const rect = (rectSource ?? el).getBoundingClientRect();
   const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-  const naturalW = elRect.width  / scale;
-  const naturalH = elRect.height / scale;
+  return {
+    left:   (rect.left - slideRect.left) / scale,
+    top:    (rect.top  - slideRect.top)  / scale,
+    width:  rect.width  / scale,
+    height: rect.height / scale,
+    scale,
+    slideEl,
+  };
+}
+
+/**
+ * Lock the element's natural width/height + padding so it doesn't collapse
+ * or stretch when reparented into the inline-block `editable-container`.
+ *
+ * Uses `getBoundingClientRect().width / scale` rather than `offsetWidth` to
+ * preserve sub-pixel accuracy — `offsetWidth` truncates to an integer, which
+ * causes inline-block text to wrap when the true content width is fractional
+ * (e.g. 208.28px collapsing to 208px).
+ *
+ * Pass `displayOverride` to set `el.style.display` after locking (tables
+ * pass nothing and set `display:table` after dataset stamping instead).
+ */
+export function lockNaturalDimensions(el, displayOverride) {
+  const scale = getSlideScale();
+  const elRect = el.getBoundingClientRect();
   const cs = window.getComputedStyle(el);
   el.style.paddingLeft   = cs.paddingLeft;
   el.style.paddingRight  = cs.paddingRight;
   el.style.paddingTop    = cs.paddingTop;
   el.style.paddingBottom = cs.paddingBottom;
   el.style.margin        = '0';
-  el.style.width         = naturalW + 'px';
-  el.style.height        = naturalH + 'px';
+  el.style.width         = (elRect.width  / scale) + 'px';
+  el.style.height        = (elRect.height / scale) + 'px';
   if (displayOverride) el.style.display = displayOverride;
-  // Suppress unused warnings — slideRect kept for parity with first-activation path
-  void slideRect;
 }
 
 /**
@@ -1116,6 +1137,50 @@ export function wrapLinesWithAbsoluteFence(lines, block, attrs) {
 }
 
 /**
+ * Sort `els` in place by their `dataset[attrName]` parsed as an integer.
+ * Missing attrs sort as 0. Used by serialize() paths that recover the
+ * classify-time positional index recorded on each element.
+ */
+export function sortByIndexAttr(els, attrName) {
+  els.sort((a, b) =>
+    parseInt(a.dataset[attrName] ?? '0', 10) -
+    parseInt(b.dataset[attrName] ?? '0', 10)
+  );
+}
+
+/**
+ * Iterate `items` from last to first, invoking `fn(item, i)`. Used by
+ * serialize() paths that splice into a `lines` array — iterating in reverse
+ * keeps the indices of earlier items stable across insertions.
+ */
+export function forEachInReverse(items, fn) {
+  for (let i = items.length - 1; i >= 0; i--) fn(items[i], i);
+}
+
+/**
+ * Group registered, modify-mode elements by the QMD chunk that holds their
+ * source. Reads `dataset.editableModifiedSlide` to map each element to a
+ * chunk index. Skips elements not in `editableRegistry` and elements whose
+ * slide maps past the end of the chunk array.
+ *
+ * Returns `{ chunks, byChunk }` — callers mutate `chunks[chunkIndex]` in
+ * place and `return chunks.join('')` at the end.
+ */
+export function groupModifiedElementsByChunk(els, text) {
+  const chunks = splitIntoSlideChunks(text);
+  const byChunk = new Map();
+  for (const el of els) {
+    if (!editableRegistry.has(el)) continue;
+    const slideIndex = parseInt(el.dataset.editableModifiedSlide ?? '0', 10);
+    const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
+    if (chunkIndex >= chunks.length) continue;
+    if (!byChunk.has(chunkIndex)) byChunk.set(chunkIndex, []);
+    byChunk.get(chunkIndex).push(el);
+  }
+  return { chunks, byChunk };
+}
+
+/**
  * Build the updated fence opening line with absolute position attrs merged in.
  * Preserves existing classes/attrs on the fence and appends the position data.
  */
@@ -1203,12 +1268,7 @@ ModifyModeClassifier.register({
 
     // Capture natural position in slide-space coordinates before setup reparents
     // the element into the absolute editable-container (which starts at 0,0).
-    const slideEl = div.closest('section');
-    const scale = getSlideScale();
-    const divRect   = div.getBoundingClientRect();
-    const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-    const origLeft = (divRect.left - slideRect.left) / scale;
-    const origTop  = (divRect.top  - slideRect.top)  / scale;
+    const { left: origLeft, top: origTop } = captureSlideRelativePosition(div);
 
     if (div.dataset.editableModifiedFenceType === 'columns') {
       setCapabilityOverride(div, ['move', 'resize', 'rotate']);
@@ -1231,18 +1291,8 @@ ModifyModeClassifier.register({
     );
     if (divs.length === 0) return text;
 
-    const chunks = splitIntoSlideChunks(text);
-
     // Group by chunk, then replace fence lines
-    const byChunk = new Map();
-    for (const div of divs) {
-      if (!editableRegistry.has(div)) continue;
-      const slideIndex = parseInt(div.dataset.editableModifiedSlide ?? '0', 10);
-      const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-      if (chunkIndex >= chunks.length) continue;
-      if (!byChunk.has(chunkIndex)) byChunk.set(chunkIndex, []);
-      byChunk.get(chunkIndex).push(div);
-    }
+    const { chunks, byChunk } = groupModifiedElementsByChunk(divs, text);
 
     for (const [chunkIndex, chunkDivs] of byChunk) {
       // Re-parse once per chunk (source may have been modified by other serializers)
@@ -1398,12 +1448,7 @@ ModifyModeClassifier.register({
 
   activate(p) {
     const slideIndex = Reveal.getState().indexh;
-    const slideEl = p.closest('section');
-    const scale = getSlideScale();
-    const pRect = p.getBoundingClientRect();
-    const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-    const origLeft = (pRect.left - slideRect.left) / scale;
-    const origTop  = (pRect.top  - slideRect.top)  / scale;
+    const { left: origLeft, top: origTop } = captureSlideRelativePosition(p);
 
     p.dataset.editableModifiedParagraph = 'true';
     p.dataset.editableModifiedSlide = String(slideIndex);
@@ -1420,32 +1465,18 @@ ModifyModeClassifier.register({
     );
     if (paras.length === 0) return text;
 
-    const chunks = splitIntoSlideChunks(text);
-
-    const byChunk = new Map();
-    for (const p of paras) {
-      if (!editableRegistry.has(p)) continue;
-      const slideIndex = parseInt(p.dataset.editableModifiedSlide ?? '0', 10);
-      const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-      if (chunkIndex >= chunks.length) continue;
-      if (!byChunk.has(chunkIndex)) byChunk.set(chunkIndex, []);
-      byChunk.get(chunkIndex).push(p);
-    }
+    const { chunks, byChunk } = groupModifiedElementsByChunk(paras, text);
 
     for (const [chunkIndex, chunkParas] of byChunk) {
-      chunkParas.sort((a, b) =>
-        parseInt(a.dataset.editableModifiedParagraphIdx ?? '0', 10) -
-        parseInt(b.dataset.editableModifiedParagraphIdx ?? '0', 10)
-      );
+      sortByIndexAttr(chunkParas, 'editableModifiedParagraphIdx');
 
       const paraBlocks = extractParagraphBlocks(chunks[chunkIndex]);
       const lines = chunks[chunkIndex].split('\n');
 
       // Process bottom-to-top so line splices don't shift earlier indices
-      for (let i = chunkParas.length - 1; i >= 0; i--) {
-        const p = chunkParas[i];
+      forEachInReverse(chunkParas, (p) => {
         const paraIdx = parseInt(p.dataset.editableModifiedParagraphIdx ?? '0', 10);
-        if (paraIdx >= paraBlocks.length) continue;
+        if (paraIdx >= paraBlocks.length) return;
 
         const block = paraBlocks[paraIdx];
         const dims = editableRegistry.get(p).toDimensions();
@@ -1463,7 +1494,7 @@ ModifyModeClassifier.register({
           content,
           ':::',
         );
-      }
+      });
 
       chunks[chunkIndex] = lines.join('\n');
     }
@@ -1563,27 +1594,8 @@ function makeListClassifier({ tagName, dataKey, testLine, label }) {
 
     activate(el) {
       const slideIndex = Reveal.getState().indexh;
-      const slideEl = el.closest('section');
-      const scale = getSlideScale();
-      const elRect = el.getBoundingClientRect();
-      const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-      const origLeft = (elRect.left - slideRect.left) / scale;
-      const origTop  = (elRect.top  - slideRect.top)  / scale;
-
-      const cs = window.getComputedStyle(el);
-      // Use getBoundingClientRect (already computed as elRect) for sub-pixel accuracy.
-      // offsetWidth truncates to integer and causes text to wrap when the true
-      // content width is fractional (e.g. 208.28px rounds to 208px).
-      const naturalW = elRect.width / scale;
-      const naturalH = elRect.height / scale;
-      el.style.paddingLeft   = cs.paddingLeft;
-      el.style.paddingRight  = cs.paddingRight;
-      el.style.paddingTop    = cs.paddingTop;
-      el.style.paddingBottom = cs.paddingBottom;
-      el.style.margin        = '0';
-      el.style.width         = naturalW + 'px';
-      el.style.height        = naturalH + 'px';
-      el.style.display       = 'block';
+      const { left: origLeft, top: origTop } = captureSlideRelativePosition(el);
+      lockNaturalDimensions(el, 'block');
 
       el.dataset[activeAttr] = 'true';
       el.dataset.editableModifiedSlide = String(slideIndex);
@@ -1600,31 +1612,17 @@ function makeListClassifier({ tagName, dataKey, testLine, label }) {
       );
       if (els.length === 0) return text;
 
-      const chunks = splitIntoSlideChunks(text);
-      const byChunk = new Map();
-
-      for (const el of els) {
-        if (!editableRegistry.has(el)) continue;
-        const slideIndex = parseInt(el.dataset.editableModifiedSlide ?? '0', 10);
-        const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-        if (chunkIndex >= chunks.length) continue;
-        if (!byChunk.has(chunkIndex)) byChunk.set(chunkIndex, []);
-        byChunk.get(chunkIndex).push(el);
-      }
+      const { chunks, byChunk } = groupModifiedElementsByChunk(els, text);
 
       for (const [chunkIndex, chunkEls] of byChunk) {
-        chunkEls.sort((a, b) =>
-          parseInt(a.dataset[idxAttr] ?? '0', 10) -
-          parseInt(b.dataset[idxAttr] ?? '0', 10)
-        );
+        sortByIndexAttr(chunkEls, idxAttr);
 
         const blocks = extractBlocksStartingWith(chunks[chunkIndex], testLine);
         const lines = chunks[chunkIndex].split('\n');
 
-        for (let i = chunkEls.length - 1; i >= 0; i--) {
-          const el = chunkEls[i];
+        forEachInReverse(chunkEls, (el) => {
           const elIdx = parseInt(el.dataset[idxAttr] ?? '0', 10);
-          if (elIdx >= blocks.length) continue;
+          if (elIdx >= blocks.length) return;
 
           const block = blocks[elIdx];
           const dims = editableRegistry.get(el).toDimensions();
@@ -1637,7 +1635,7 @@ function makeListClassifier({ tagName, dataKey, testLine, label }) {
             block.text,
             ':::',
           );
-        }
+        });
 
         chunks[chunkIndex] = lines.join('\n');
       }
@@ -2155,26 +2153,10 @@ ModifyModeClassifier.register({
 
   activate(el) {
     const slideIndex = Reveal.getState().indexh;
-    const slideEl = el.closest('section');
-    const scale = getSlideScale();
-    const elRect = el.getBoundingClientRect();
-    const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-    const origLeft = (elRect.left - slideRect.left) / scale;
-    const origTop  = (elRect.top  - slideRect.top)  / scale;
-
+    const { left: origLeft, top: origTop } = captureSlideRelativePosition(el);
     // Lock natural dimensions before setup so reparenting into the inline-block
     // editable-container doesn't collapse or stretch the block.
-    const cs = window.getComputedStyle(el);
-    const naturalW = elRect.width / scale;
-    const naturalH = elRect.height / scale;
-    el.style.paddingLeft   = cs.paddingLeft;
-    el.style.paddingRight  = cs.paddingRight;
-    el.style.paddingTop    = cs.paddingTop;
-    el.style.paddingBottom = cs.paddingBottom;
-    el.style.margin        = '0';
-    el.style.width         = naturalW + 'px';
-    el.style.height        = naturalH + 'px';
-    el.style.display       = 'block';
+    lockNaturalDimensions(el, 'block');
 
     el.dataset.editableModifiedCode = 'true';
     el.dataset.editableModifiedSlide = String(slideIndex);
@@ -2193,36 +2175,23 @@ ModifyModeClassifier.register({
     );
     if (els.length === 0) return text;
 
-    const chunks = splitIntoSlideChunks(text);
-    const byChunk = new Map();
-    for (const el of els) {
-      if (!editableRegistry.has(el)) continue;
-      const slideIndex = parseInt(el.dataset.editableModifiedSlide ?? '0', 10);
-      const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-      if (chunkIndex >= chunks.length) continue;
-      if (!byChunk.has(chunkIndex)) byChunk.set(chunkIndex, []);
-      byChunk.get(chunkIndex).push(el);
-    }
+    const { chunks, byChunk } = groupModifiedElementsByChunk(els, text);
 
     for (const [chunkIndex, chunkEls] of byChunk) {
-      chunkEls.sort((a, b) =>
-        parseInt(a.dataset.editableModifiedCodeIdx ?? '0', 10) -
-        parseInt(b.dataset.editableModifiedCodeIdx ?? '0', 10)
-      );
+      sortByIndexAttr(chunkEls, 'editableModifiedCodeIdx');
 
       const blocks = extractCodeBlocks(chunks[chunkIndex]);
       const lines = chunks[chunkIndex].split('\n');
 
       // Bottom-to-top so line splices don't shift earlier indices.
-      for (let i = chunkEls.length - 1; i >= 0; i--) {
-        const el = chunkEls[i];
+      forEachInReverse(chunkEls, (el) => {
         const codeIdx = parseInt(el.dataset.editableModifiedCodeIdx ?? '0', 10);
-        if (codeIdx >= blocks.length) continue;
+        if (codeIdx >= blocks.length) return;
 
         // Safety: verify the positional match still names the same code block.
         const expectedFirst = (el.dataset.editableModifiedCodeFirstLine ?? '').trim();
         const actualFirst   = (blocks[codeIdx].firstCodeLine ?? '').trim();
-        if (expectedFirst && actualFirst && expectedFirst !== actualFirst) continue;
+        if (expectedFirst && actualFirst && expectedFirst !== actualFirst) return;
 
         const block = blocks[codeIdx];
         const dims = editableRegistry.get(el).toDimensions();
@@ -2230,7 +2199,7 @@ ModifyModeClassifier.register({
         const attrs = buildAbsoluteAttrString(dims);
 
         wrapLinesWithAbsoluteFence(lines, block, attrs);
-      }
+      });
 
       chunks[chunkIndex] = lines.join('\n');
     }
@@ -2384,26 +2353,10 @@ ModifyModeClassifier.register({
 
   activate(el) {
     const slideIndex = Reveal.getState().indexh;
-    const slideEl = el.closest('section');
-    const scale = getSlideScale();
-    const elRect = el.getBoundingClientRect();
-    const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-    const origLeft = (elRect.left - slideRect.left) / scale;
-    const origTop  = (elRect.top  - slideRect.top)  / scale;
-
+    const { left: origLeft, top: origTop } = captureSlideRelativePosition(el);
     // Lock natural dimensions before setup; without this, reparenting into the
     // inline-block editable-container collapses the cell width.
-    const cs = window.getComputedStyle(el);
-    const naturalW = elRect.width / scale;
-    const naturalH = elRect.height / scale;
-    el.style.paddingLeft   = cs.paddingLeft;
-    el.style.paddingRight  = cs.paddingRight;
-    el.style.paddingTop    = cs.paddingTop;
-    el.style.paddingBottom = cs.paddingBottom;
-    el.style.margin        = '0';
-    el.style.width         = naturalW + 'px';
-    el.style.height        = naturalH + 'px';
-    el.style.display       = 'block';
+    lockNaturalDimensions(el, 'block');
 
     el.dataset.editableModifiedCell = 'true';
     el.dataset.editableModifiedSlide = String(slideIndex);
@@ -2419,29 +2372,16 @@ ModifyModeClassifier.register({
     );
     if (els.length === 0) return text;
 
-    const chunks = splitIntoSlideChunks(text);
-    const byChunk = new Map();
-    for (const el of els) {
-      if (!editableRegistry.has(el)) continue;
-      const slideIndex = parseInt(el.dataset.editableModifiedSlide ?? '0', 10);
-      const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-      if (chunkIndex >= chunks.length) continue;
-      if (!byChunk.has(chunkIndex)) byChunk.set(chunkIndex, []);
-      byChunk.get(chunkIndex).push(el);
-    }
+    const { chunks, byChunk } = groupModifiedElementsByChunk(els, text);
 
     for (const [chunkIndex, chunkEls] of byChunk) {
-      chunkEls.sort((a, b) =>
-        parseInt(a.dataset.editableModifiedCellIdx ?? '0', 10) -
-        parseInt(b.dataset.editableModifiedCellIdx ?? '0', 10)
-      );
+      sortByIndexAttr(chunkEls, 'editableModifiedCellIdx');
 
       const execChunks = extractExecutableChunks(chunks[chunkIndex]);
       const lines = chunks[chunkIndex].split('\n');
 
       // Bottom-to-top so line splices don't shift earlier indices.
-      for (let i = chunkEls.length - 1; i >= 0; i--) {
-        const el = chunkEls[i];
+      forEachInReverse(chunkEls, (el) => {
         const cellLabel = el.dataset.editableModifiedCellLabel || '';
         const cellFirstLine = (el.dataset.editableModifiedCellFirstLine ?? '').trim();
         const cellIdx = parseInt(el.dataset.editableModifiedCellIdx ?? '-1', 10);
@@ -2459,13 +2399,13 @@ ModifyModeClassifier.register({
             target = candidate;
           }
         }
-        if (!target) continue;
+        if (!target) return;
 
         const dims = editableRegistry.get(el).toDimensions();
         const attrs = buildAbsoluteAttrString(dims);
 
         wrapLinesWithAbsoluteFence(lines, target, attrs);
-      }
+      });
 
       chunks[chunkIndex] = lines.join('\n');
     }
@@ -2595,29 +2535,16 @@ ModifyModeClassifier.register({
     );
     if (imgs.length === 0) return text;
 
-    const chunks = splitIntoSlideChunks(text);
-    const byChunk = new Map();
-    for (const img of imgs) {
-      if (!editableRegistry.has(img)) continue;
-      const slideIndex = parseInt(img.dataset.editableModifiedSlide ?? '0', 10);
-      const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-      if (chunkIndex >= chunks.length) continue;
-      if (!byChunk.has(chunkIndex)) byChunk.set(chunkIndex, []);
-      byChunk.get(chunkIndex).push(img);
-    }
+    const { chunks, byChunk } = groupModifiedElementsByChunk(imgs, text);
 
     for (const [chunkIndex, chunkImgs] of byChunk) {
-      chunkImgs.sort((a, b) =>
-        parseInt(a.dataset.editableModifiedChunkFigExecIdx ?? '0', 10) -
-        parseInt(b.dataset.editableModifiedChunkFigExecIdx ?? '0', 10)
-      );
+      sortByIndexAttr(chunkImgs, 'editableModifiedChunkFigExecIdx');
 
       const execChunks = extractExecutableChunks(chunks[chunkIndex]);
       const lines = chunks[chunkIndex].split('\n');
 
       // Bottom-to-top so splices don't shift earlier line indices.
-      for (let i = chunkImgs.length - 1; i >= 0; i--) {
-        const img = chunkImgs[i];
+      forEachInReverse(chunkImgs, (img) => {
         const label = img.dataset.editableModifiedChunkFigLabel || '';
         const firstLine = (img.dataset.editableModifiedChunkFigFirstLine ?? '').trim();
         const execIdx = parseInt(img.dataset.editableModifiedChunkFigExecIdx ?? '-1', 10);
@@ -2633,13 +2560,13 @@ ModifyModeClassifier.register({
             target = candidate;
           }
         }
-        if (!target) continue;
+        if (!target) return;
 
         const dims = editableRegistry.get(img).toDimensions();
         const attrs = buildAbsoluteAttrString(dims);
 
         wrapLinesWithAbsoluteFence(lines, target, attrs);
-      }
+      });
 
       chunks[chunkIndex] = lines.join('\n');
     }
@@ -2848,24 +2775,9 @@ ModifyModeClassifier.register({
 
   activate(el) {
     const slideIndex = Reveal.getState().indexh;
-    const slideEl = el.closest('section');
-    const scale = getSlideScale();
-    const elRect = el.getBoundingClientRect();
-    const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-    const origLeft = (elRect.left - slideRect.left) / scale;
-    const origTop  = (elRect.top  - slideRect.top)  / scale;
-
-    const cs = window.getComputedStyle(el);
-    const naturalW = elRect.width / scale;
-    const naturalH = elRect.height / scale;
+    const { left: origLeft, top: origTop } = captureSlideRelativePosition(el);
     const isTable = el.tagName === 'TABLE';
-    el.style.paddingLeft   = cs.paddingLeft;
-    el.style.paddingRight  = cs.paddingRight;
-    el.style.paddingTop    = cs.paddingTop;
-    el.style.paddingBottom = cs.paddingBottom;
-    el.style.margin        = '0';
-    el.style.width         = naturalW + 'px';
-    el.style.height        = naturalH + 'px';
+    lockNaturalDimensions(el);
 
     el.dataset.editableModifiedTable = 'true';
     el.dataset.editableModifiedSlide = String(slideIndex);
@@ -2885,22 +2797,10 @@ ModifyModeClassifier.register({
     );
     if (els.length === 0) return text;
 
-    const chunks = splitIntoSlideChunks(text);
-    const byChunk = new Map();
-    for (const el of els) {
-      if (!editableRegistry.has(el)) continue;
-      const slideIndex = parseInt(el.dataset.editableModifiedSlide ?? '0', 10);
-      const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-      if (chunkIndex >= chunks.length) continue;
-      if (!byChunk.has(chunkIndex)) byChunk.set(chunkIndex, []);
-      byChunk.get(chunkIndex).push(el);
-    }
+    const { chunks, byChunk } = groupModifiedElementsByChunk(els, text);
 
     for (const [chunkIndex, chunkEls] of byChunk) {
-      chunkEls.sort((a, b) =>
-        parseInt(a.dataset.editableModifiedTableIdx ?? '0', 10) -
-        parseInt(b.dataset.editableModifiedTableIdx ?? '0', 10)
-      );
+      sortByIndexAttr(chunkEls, 'editableModifiedTableIdx');
 
       const sourceTables = extractTables(chunks[chunkIndex]);
       const lines = chunks[chunkIndex].split('\n');
@@ -3079,19 +2979,12 @@ ModifyModeClassifier.register({
 
   activate(el) {
     const slideIndex = Reveal.getState().indexh;
-    const slideEl = el.closest('section');
-    const scale = getSlideScale();
-    const slideRect = slideEl ? slideEl.getBoundingClientRect() : { left: 0, top: 0 };
-
     // Anchor on the rendered math node when available so the container's
     // top edge sits at the visible top of the equation (not the top of the
     // wrapping `<p>`'s margin box, which would shift the equation down).
     const inner = el.querySelector('.MathJax_Display, mjx-container, .katex-display, span.math.display') ?? el;
-    const innerRect = inner.getBoundingClientRect();
-    const origLeft = (innerRect.left - slideRect.left) / scale;
-    const origTop  = (innerRect.top  - slideRect.top)  / scale;
-    const naturalW = innerRect.width  / scale;
-    const naturalH = innerRect.height / scale;
+    const { left: origLeft, top: origTop, width: naturalW, height: naturalH } =
+      captureSlideRelativePosition(el, { rectSource: inner });
 
     el.style.padding = '0';
     el.style.margin  = '0';
@@ -3115,22 +3008,10 @@ ModifyModeClassifier.register({
     );
     if (els.length === 0) return text;
 
-    const chunks = splitIntoSlideChunks(text);
-    const byChunk = new Map();
-    for (const el of els) {
-      if (!editableRegistry.has(el)) continue;
-      const slideIndex = parseInt(el.dataset.editableModifiedSlide ?? '0', 10);
-      const chunkIndex = getQmdHeadingIndex(slideIndex) + 1;
-      if (chunkIndex >= chunks.length) continue;
-      if (!byChunk.has(chunkIndex)) byChunk.set(chunkIndex, []);
-      byChunk.get(chunkIndex).push(el);
-    }
+    const { chunks, byChunk } = groupModifiedElementsByChunk(els, text);
 
     for (const [chunkIndex, chunkEls] of byChunk) {
-      chunkEls.sort((a, b) =>
-        parseInt(a.dataset.editableModifiedEqIdx ?? '0', 10) -
-        parseInt(b.dataset.editableModifiedEqIdx ?? '0', 10)
-      );
+      sortByIndexAttr(chunkEls, 'editableModifiedEqIdx');
 
       const sourceEqs = extractDisplayEquations(chunks[chunkIndex]);
       const lines = chunks[chunkIndex].split('\n');

--- a/_extensions/editable/src/utils.js
+++ b/_extensions/editable/src/utils.js
@@ -15,6 +15,14 @@ export function round(n) {
 }
 
 /**
+ * Escape regex metacharacters in a string so it can be embedded literally
+ * in a `new RegExp(...)` pattern.
+ */
+export function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Log a debug message (only when DEBUG mode is enabled).
  * @param {...any} args - Arguments to log
  */


### PR DESCRIPTION
## Summary

First mechanical step of the modify-mode dedup plan. Extracts six shared helpers used across the 12 classifiers in `src/modify-mode.js`. Behavior-preserving.

- `escapeRegex` → `src/utils.js` (was duplicated in `modify-mode.js` and `modify-mode-positioned.js`).
- `captureSlideRelativePosition(el, { rectSource })` — replaces ~7 inline copies of the `slideEl` / `getSlideScale` / `getBoundingClientRect` dance. `rectSource` lets the equation classifier anchor on the inner math node.
- `lockNaturalDimensions(el, displayOverride)` — now used by lists/blockquotes, code blocks, code-chunk outputs, and tables (previously inline).
- `sortByIndexAttr(els, attrName)` — replaces 8 per-classifier sort-by-dataset-index blocks.
- `forEachInReverse(items, fn)` — names the bottom-to-top splice idiom used by 5 serialize() paths.
- `groupModifiedElementsByChunk(els, text)` — replaces the byChunk Map construction at the top of 8 serialize() methods.

`modify-mode.js`: 3294 → 3175 lines (-119 net; classifier bodies shrink more, helpers add ~120 lines of definitions+JSDoc).

## Test plan

- [x] `npm run test:run` — 189 unit tests pass, including 24 new helper tests
- [x] `testing/run-tests.sh` — all 37 shell tests pass
- [x] `npm run test:e2e` — 851 E2E tests pass on Chromium + Firefox (7 skipped)
- [ ] Manual smoke: render `basic.qmd`, click one element of each classifier type in modify mode, save, diff QMD against `main` (see plan §Manual smoke)

Refs the PR 1 step of `~/Desktop/plans/2026-05-12-modify-mode-dedup.md`.